### PR TITLE
chore: prepare PyPI release (1.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+# Build the distribution and publish it to PyPI.
+#
+# Publishing uses PyPI Trusted Publishing (OpenID Connect) — there are NO
+# stored API tokens or passwords. The exchange of the short-lived OIDC token
+# is what requires `permissions: id-token: write` on the publishing jobs.
+#
+# Triggers:
+#   * push of a tag matching `v*` (e.g. v1.1.0) -> publish to PyPI
+#   * manual `workflow_dispatch`                -> publish to TestPyPI (dry run)
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: twine check --strict dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish to PyPI for an actual version tag push.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/project/libopenschichtplaner5/
+    permissions:
+      id-token: write   # mandatory for Trusted Publishing (OIDC)
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Manual dry-run publish to TestPyPI.
+    if: github.event_name == 'workflow_dispatch'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/libopenschichtplaner5/
+    permissions:
+      id-token: write   # mandatory for Trusted Publishing (OIDC)
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-05-26
+
+Initial standalone release of **libopenschichtplaner5** (import name `sp5lib`).
+
+This is the first release of the library as an independent, pip-installable
+package. The code was extracted — **with its full git history** — from the
+`backend/sp5lib/` directory of
+[OpenSchichtplaner5](https://github.com/mschabhuettl/openschichtplaner5).
+The `1.1.0` version preserves the version line the library carried inside that
+project, so there is no regression for existing consumers; OpenSchichtplaner5
+continues to import it unchanged as `sp5lib`.
+
+### Added
+
+- Packaging as the `libopenschichtplaner5` distribution (importable as `sp5lib`),
+  publishable to PyPI with an sdist and a pure-Python wheel.
+- `sp5lib.dbf_reader` — pure-Python DBF reader (UTF-16-LE detection, date
+  parsing, field decoding) for the original Schichtplaner5 FoxPro/dBASE files.
+- `sp5lib.dbf_writer` — safe DBF writer with exclusive `flock`, TOCTOU-safe
+  record counting, rollback, and EOF-marker preservation.
+- `sp5lib.database` — high-level `SP5Database` facade over the DBF tables
+  (employees, shifts, schedule, absences, authentication, 2FA, …).
+- `sp5lib.db_factory`, `sp5lib.sqlite_adapter`, `sp5lib.pg_database` — optional
+  SQLite and PostgreSQL backends.
+- `sp5lib.orm` — SQLAlchemy models (SQLite `models.py`, PostgreSQL
+  `models_pg.py`), `repository`, and `sync`.
+- `sp5lib.auto_migrate` — Alembic-based automatic migrations.
+- `sp5lib.email_service` — SMTP notification emails with HTML-escaped templates.
+- `sp5lib.color_utils` — FoxPro BGR ↔ hex/RGB color helpers.
+- `py.typed` marker so type checkers consume the bundled type hints.
+- `postgres` extra (`psycopg2-binary`) for the optional PostgreSQL backend.
+- Continuous integration running ruff and pytest on Python 3.10–3.12.
+- Release workflow publishing to PyPI via Trusted Publishing on `v*` tags.
+
+### Notes
+
+- Runtime dependencies: `SQLAlchemy`, `alembic`, `bcrypt`, `pyotp`, `packaging`.
+- Requires Python 3.10 or newer.
+- Licensed under the MIT License.
+
+[1.1.0]: https://github.com/mschabhuettl/libopenschichtplaner5/releases/tag/v1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,29 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
 version = "1.1.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
-readme = "README.md"
-license = { text = "MIT" }
-authors = [{ name = "Matthias Schabhüttl" }]
+readme = { file = "README.md", content-type = "text/markdown" }
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Matthias Schabhüttl", email = "matthias@matthiasschabhuettl.com" }]
 requires-python = ">=3.10"
 keywords = ["schichtplaner5", "dbf", "foxpro", "shift-planning", "dbase"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Database",
     "Topic :: Office/Business :: Scheduling",
+    "Typing :: Typed",
 ]
 dependencies = [
     "SQLAlchemy>=2.0.0",
@@ -40,7 +43,9 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/mschabhuettl/libopenschichtplaner5"
-"Source" = "https://github.com/mschabhuettl/libopenschichtplaner5"
+Source = "https://github.com/mschabhuettl/libopenschichtplaner5"
+Changelog = "https://github.com/mschabhuettl/libopenschichtplaner5/blob/main/CHANGELOG.md"
+Issues = "https://github.com/mschabhuettl/libopenschichtplaner5/issues"
 "Main application" = "https://github.com/mschabhuettl/openschichtplaner5"
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

Prepares **libopenschichtplaner5** for its first PyPI release (version **1.1.0**, kept as-is). This PR is **release prep only** — nothing has been published to PyPI or TestPyPI.

The distribution builds clean and passes strict metadata validation:

```
python -m build          # warning-free sdist + wheel
twine check --strict dist/*   # both PASSED
ruff check .             # All checks passed!
pytest                   # 14 passed
```

## Changes

### `build:` PyPI-ready `pyproject.toml` (PEP 639)
- Switched to an SPDX `license = "MIT"` expression + `license-files = ["LICENSE"]`, and removed the deprecated `License :: OSI Approved :: MIT License` classifier. This eliminates the `setuptools>=77` deprecation warnings emitted during the build.
- Bumped the build requirement to `setuptools>=77.0.0` (needed for SPDX license support → Metadata 2.4 `License-Expression`).
- Made the README content-type explicit (`text/markdown`).
- Added author email, `Operating System :: OS Independent`, `Typing :: Typed`, Python `3.13`, and `Changelog` / `Issues` project URLs.
- Version stays **1.1.0**.

### `ci:` `.github/workflows/release.yml` — Trusted Publishing
- `build` job: builds sdist + wheel and runs `twine check --strict`, uploading the artifact.
- `publish-pypi` job: runs on a pushed `v*` tag, uses `pypa/gh-action-pypi-publish@release/v1` with `permissions: id-token: write`, environment `pypi`.
- `publish-testpypi` job: runs on `workflow_dispatch` (manual dry run) and publishes to TestPyPI via the same action with `repository-url: https://test.pypi.org/legacy/`, environment `testpypi`.
- **No stored tokens or passwords** — authentication is entirely OIDC-based PyPI Trusted Publishing.

### `docs:` `CHANGELOG.md`
- Documents 1.1.0 as the first standalone, pip-installable release, extracted **with full git history** from OpenSchichtplaner5's `backend/sp5lib/`.

### Housekeeping
- `dist/`, `build/`, and `.venv/` were already present in `.gitignore`, so no change was required there (verified the build artifacts and venv stay untracked).
- Existing CI (`ci.yml`) is untouched and remains green; `ruff check .` is clean.

## How to cut a release

This requires **one-time setup** on PyPI and GitHub before the first publish, because Trusted Publishing maps a GitHub repo + workflow + environment to a PyPI project — no secrets are stored.

1. **Create the PyPI Trusted Publisher** (one time). On PyPI → project (or "pending publisher") → *Publishing* → add a GitHub publisher:
   - Owner: `mschabhuettl`, Repository: `libopenschichtplaner5`
   - Workflow filename: `release.yml`
   - Environment name: `pypi`
   - Repeat on **TestPyPI** with environment `testpypi` if you want the dry-run path.
2. **Create the GitHub environments** (one time): repo *Settings → Environments* → add `pypi` (and `testpypi`). Optionally add required reviewers / tag protection as a guardrail.
3. **(Optional) Dry run to TestPyPI**: *Actions → Release → Run workflow* (`workflow_dispatch`) → publishes to TestPyPI.
4. **Publish to PyPI**: tag and push.
   ```bash
   git checkout main && git pull
   git tag v1.1.0
   git push origin v1.1.0
   ```
   The pushed `v1.1.0` tag triggers the `build` → `publish-pypi` jobs and publishes via OIDC.

> Note: the version in `pyproject.toml` (`1.1.0`) must match the tag (`v1.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)