### PR TITLE
ci: bump artifact actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: twine check --strict dist/*
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/
@@ -59,7 +59,7 @@ jobs:
       id-token: write   # mandatory for Trusted Publishing (OIDC)
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/
@@ -80,7 +80,7 @@ jobs:
       id-token: write   # mandatory for Trusted Publishing (OIDC)
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

Bumps the artifact actions in `.github/workflows/release.yml` from `@v4` to `@v5` to clear the Node 20 deprecation warning that surfaced on the 1.1.0 release run.

`actions/upload-artifact@v4` and `actions/download-artifact@v4` run on Node 20. GitHub is deprecating Node 20 on Actions runners — forced to Node 24 on **2026-06-02**, removed **2026-09-16**. The `@v5` releases run on Node 24.

## Changes

- `actions/upload-artifact@v4` → `@v5` (build job)
- `actions/download-artifact@v4` → `@v5` (publish-pypi + publish-testpypi jobs)

`upload-artifact` v5 and `download-artifact` v5 are wire-compatible, so the `build` → publish artifact handoff is unchanged. No behavioral change to the release flow; the next `v*` tag will publish exactly as before, just without the deprecation warning.

## Notes

- YAML validated locally (`jobs: build, publish-pypi, publish-testpypi`).
- The `ci.yml` workflow already uses `checkout@v5` / `setup-python@v6` and has no artifact steps, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)