### PR TITLE
feat(orm): Phase 2 — Shift, LeaveType & Workplace models, repos, sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-27
+
+ORM Phase 2 — adds the next three core entities to the SQLAlchemy layer
+(`sp5lib.orm`), mirroring the Phase 1 Employee/Group patterns. Additive and
+backward compatible.
+
+### Added
+
+- **`Shift`** (`shifts`, from `5SHIFT.DBF`), **`LeaveType`** (`leave_types`,
+  `5LEAVT.DBF`) and **`Workplace`** (`workplaces`, `5WOPL.DBF`) ORM models,
+  importable directly from `sp5lib.orm`. `init_db()` creates the tables.
+- **`ShiftRepository`**, **`LeaveTypeRepository`**, **`WorkplaceRepository`**
+  with `list(include_hidden=False)` and `get(id)`.
+- DBF → ORM upsert for the three tables via `sync.sync_shifts`,
+  `sync.sync_leave_types`, `sync.sync_workplaces`; `sync.sync_all()` now also
+  returns `shifts` / `leave_types` / `workplaces` counts.
+- ORM unit tests (`tests/test_orm.py`, in-memory SQLite) covering models,
+  repositories, `to_dict()` and the sync upsert.
+
+### Changed
+
+- `Shift`, `LeaveType` and `Workplace` are now defined canonically in
+  `sp5lib.orm.models` and **re-exported** from `sp5lib.orm.models_pg` (single
+  source of truth, identical `to_dict()`). Existing
+  `from sp5lib.orm.models_pg import Shift, LeaveType, Workplace` imports keep
+  working unchanged.
+
 ## [1.1.0] - 2026-05-26
 
 Initial standalone release of **libopenschichtplaner5** (import name `sp5lib`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
-version = "1.1.0"
+version = "1.2.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/sp5lib/orm/README.md
+++ b/sp5lib/orm/README.md
@@ -34,8 +34,8 @@ layer and serves as a foundation for a future database migration (SQLite → Pos
 sp5lib/orm/
 ├── __init__.py       # Public API: get_engine, get_session, init_db
 ├── base.py           # Engine factory, session management, Base class
-├── models.py         # ORM models: Employee, Group, GroupAssignment
-├── repository.py     # Repository pattern: EmployeeRepository, GroupRepository
+├── models.py         # ORM models: Employee, Group, GroupAssignment, Shift, LeaveType, Workplace
+├── repository.py     # Repositories: Employee, Group, Shift, LeaveType, Workplace
 ├── sync.py           # DBF → ORM sync utilities
 └── README.md         # This file
 ```
@@ -83,8 +83,8 @@ This initial implementation covers:
 
 ## Migration Roadmap
 
-1. ✅ **Phase 1** (this PR): ORM models + repositories for Employees & Groups
-2. **Phase 2**: Add models for Shifts, LeaveTypes, Workplaces
+1. ✅ **Phase 1**: ORM models + repositories for Employees & Groups
+2. ✅ **Phase 2**: ORM models + repositories + DBF sync for Shifts, LeaveTypes, Workplaces
 3. **Phase 3**: Add models for Schedule entries (MASHI, SPSHI, ABSEN)
 4. **Phase 4**: Wire ORM repositories into FastAPI routers (dual-read)
 5. **Phase 5**: Switch write path to ORM, keep DBF sync for legacy

--- a/sp5lib/orm/__init__.py
+++ b/sp5lib/orm/__init__.py
@@ -18,5 +18,41 @@ Usage:
 """
 
 from .base import Base, get_engine, get_session, init_db
+from .models import (
+    Company,
+    Employee,
+    Group,
+    GroupAssignment,
+    LeaveType,
+    Shift,
+    Workplace,
+)
+from .repository import (
+    EmployeeRepository,
+    GroupRepository,
+    LeaveTypeRepository,
+    ShiftRepository,
+    WorkplaceRepository,
+)
 
-__all__ = ["Base", "get_engine", "get_session", "init_db"]
+__all__ = [
+    # Engine / session / schema
+    "Base",
+    "get_engine",
+    "get_session",
+    "init_db",
+    # Models
+    "Company",
+    "Employee",
+    "Group",
+    "GroupAssignment",
+    "Shift",
+    "LeaveType",
+    "Workplace",
+    # Repositories
+    "EmployeeRepository",
+    "GroupRepository",
+    "ShiftRepository",
+    "LeaveTypeRepository",
+    "WorkplaceRepository",
+]

--- a/sp5lib/orm/models.py
+++ b/sp5lib/orm/models.py
@@ -262,3 +262,125 @@ class GroupAssignment(Base):
 
     def __repr__(self) -> str:
         return f"<GroupAssignment(employee_id={self.employee_id}, group_id={self.group_id})>"
+
+
+# ── Phase 2: shift / leave-type / workplace definitions ──────────────────────
+# Canonical, backend-agnostic definitions (work identically on SQLite & Postgres).
+# Re-exported from models_pg.py so existing `from sp5lib.orm.models_pg import …`
+# imports keep working and the SQLite/Postgres schemas stay a single source of truth.
+
+
+class Shift(Base):
+    """Shift definition (Schicht) — maps to 5SHIFT.DBF."""
+
+    __tablename__ = "shifts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, doc="Shift name")
+    shortname: Mapped[str | None] = mapped_column(String(20), default="")
+    position: Mapped[int] = mapped_column(Integer, default=0, doc="Sort order")
+    hide: Mapped[bool] = mapped_column(Boolean, default=False, doc="Soft-deleted / hidden")
+    colortext: Mapped[int] = mapped_column(Integer, default=0)
+    colorbar: Mapped[int] = mapped_column(Integer, default=0)
+    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
+    duration0: Mapped[float] = mapped_column(Float, default=0.0)
+    duration1: Mapped[float] = mapped_column(Float, default=0.0)
+    duration2: Mapped[float] = mapped_column(Float, default=0.0)
+    duration3: Mapped[float] = mapped_column(Float, default=0.0)
+    duration4: Mapped[float] = mapped_column(Float, default=0.0)
+    duration5: Mapped[float] = mapped_column(Float, default=0.0)
+    duration6: Mapped[float] = mapped_column(Float, default=0.0)
+    duration7: Mapped[float] = mapped_column(Float, default=0.0)
+    startend0: Mapped[str | None] = mapped_column(String(50), default="")
+    startend1: Mapped[str | None] = mapped_column(String(50), default="")
+    startend2: Mapped[str | None] = mapped_column(String(50), default="")
+    startend3: Mapped[str | None] = mapped_column(String(50), default="")
+    startend4: Mapped[str | None] = mapped_column(String(50), default="")
+    startend5: Mapped[str | None] = mapped_column(String(50), default="")
+    startend6: Mapped[str | None] = mapped_column(String(50), default="")
+    startend7: Mapped[str | None] = mapped_column(String(50), default="")
+
+    def __repr__(self) -> str:
+        return f"<Shift(id={self.id}, name='{self.name}')>"
+
+    def to_dict(self) -> dict:
+        d = {
+            "ID": self.id,
+            "NAME": self.name,
+            "SHORTNAME": self.shortname or "",
+            "POSITION": self.position,
+            "HIDE": self.hide,
+            "COLORTEXT": self.colortext,
+            "COLORBAR": self.colorbar,
+            "COLORBK": self.colorbk,
+        }
+        for i in range(8):
+            d[f"DURATION{i}"] = getattr(self, f"duration{i}")
+            d[f"STARTEND{i}"] = getattr(self, f"startend{i}") or ""
+        return d
+
+
+class LeaveType(Base):
+    """Leave / absence type (Abwesenheitsart) — maps to 5LEAVT.DBF."""
+
+    __tablename__ = "leave_types"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, doc="Leave type name")
+    shortname: Mapped[str | None] = mapped_column(String(20), default="")
+    position: Mapped[int] = mapped_column(Integer, default=0, doc="Sort order")
+    hide: Mapped[bool] = mapped_column(Boolean, default=False, doc="Soft-deleted / hidden")
+    entitled: Mapped[bool] = mapped_column(Boolean, default=False)
+    stdentit: Mapped[float] = mapped_column(Float, default=0.0)
+    chargetyp: Mapped[int] = mapped_column(Integer, default=0)
+    colortext: Mapped[int] = mapped_column(Integer, default=0)
+    colorbar: Mapped[int] = mapped_column(Integer, default=0)
+    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
+
+    def __repr__(self) -> str:
+        return f"<LeaveType(id={self.id}, name='{self.name}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "NAME": self.name,
+            "SHORTNAME": self.shortname or "",
+            "POSITION": self.position,
+            "HIDE": self.hide,
+            "ENTITLED": self.entitled,
+            "STDENTIT": self.stdentit,
+            "CHARGETYP": self.chargetyp,
+            "COLORTEXT": self.colortext,
+            "COLORBAR": self.colorbar,
+            "COLORBK": self.colorbk,
+        }
+
+
+class Workplace(Base):
+    """Workplace / location (Arbeitsplatz) — maps to 5WOPL.DBF."""
+
+    __tablename__ = "workplaces"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, doc="Workplace name")
+    shortname: Mapped[str | None] = mapped_column(String(20), default="")
+    position: Mapped[int] = mapped_column(Integer, default=0, doc="Sort order")
+    hide: Mapped[bool] = mapped_column(Boolean, default=False, doc="Soft-deleted / hidden")
+    colortext: Mapped[int] = mapped_column(Integer, default=0)
+    colorbar: Mapped[int] = mapped_column(Integer, default=0)
+    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
+
+    def __repr__(self) -> str:
+        return f"<Workplace(id={self.id}, name='{self.name}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "NAME": self.name,
+            "SHORTNAME": self.shortname or "",
+            "POSITION": self.position,
+            "HIDE": self.hide,
+            "COLORTEXT": self.colortext,
+            "COLORBAR": self.colorbar,
+            "COLORBK": self.colorbk,
+        }

--- a/sp5lib/orm/models_pg.py
+++ b/sp5lib/orm/models_pg.py
@@ -19,81 +19,11 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
-
-class Shift(Base):
-    __tablename__ = "shifts"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(100), nullable=False)
-    shortname: Mapped[str | None] = mapped_column(String(20), default="")
-    position: Mapped[int] = mapped_column(Integer, default=0)
-    hide: Mapped[bool] = mapped_column(Boolean, default=False)
-    colortext: Mapped[int] = mapped_column(Integer, default=0)
-    colorbar: Mapped[int] = mapped_column(Integer, default=0)
-    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
-    duration0: Mapped[float] = mapped_column(Float, default=0.0)
-    duration1: Mapped[float] = mapped_column(Float, default=0.0)
-    duration2: Mapped[float] = mapped_column(Float, default=0.0)
-    duration3: Mapped[float] = mapped_column(Float, default=0.0)
-    duration4: Mapped[float] = mapped_column(Float, default=0.0)
-    duration5: Mapped[float] = mapped_column(Float, default=0.0)
-    duration6: Mapped[float] = mapped_column(Float, default=0.0)
-    duration7: Mapped[float] = mapped_column(Float, default=0.0)
-    startend0: Mapped[str | None] = mapped_column(String(50), default="")
-    startend1: Mapped[str | None] = mapped_column(String(50), default="")
-    startend2: Mapped[str | None] = mapped_column(String(50), default="")
-    startend3: Mapped[str | None] = mapped_column(String(50), default="")
-    startend4: Mapped[str | None] = mapped_column(String(50), default="")
-    startend5: Mapped[str | None] = mapped_column(String(50), default="")
-    startend6: Mapped[str | None] = mapped_column(String(50), default="")
-    startend7: Mapped[str | None] = mapped_column(String(50), default="")
-
-    def to_dict(self) -> dict:
-        d = {"ID": self.id, "NAME": self.name, "SHORTNAME": self.shortname or "",
-             "POSITION": self.position, "HIDE": self.hide,
-             "COLORTEXT": self.colortext, "COLORBAR": self.colorbar, "COLORBK": self.colorbk}
-        for i in range(8):
-            d[f"DURATION{i}"] = getattr(self, f"duration{i}")
-            d[f"STARTEND{i}"] = getattr(self, f"startend{i}") or ""
-        return d
-
-
-class LeaveType(Base):
-    __tablename__ = "leave_types"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(100), nullable=False)
-    shortname: Mapped[str | None] = mapped_column(String(20), default="")
-    position: Mapped[int] = mapped_column(Integer, default=0)
-    hide: Mapped[bool] = mapped_column(Boolean, default=False)
-    entitled: Mapped[bool] = mapped_column(Boolean, default=False)
-    stdentit: Mapped[float] = mapped_column(Float, default=0.0)
-    chargetyp: Mapped[int] = mapped_column(Integer, default=0)
-    colortext: Mapped[int] = mapped_column(Integer, default=0)
-    colorbar: Mapped[int] = mapped_column(Integer, default=0)
-    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
-
-    def to_dict(self) -> dict:
-        return {"ID": self.id, "NAME": self.name, "SHORTNAME": self.shortname or "",
-                "POSITION": self.position, "HIDE": self.hide,
-                "ENTITLED": self.entitled, "STDENTIT": self.stdentit,
-                "CHARGETYP": self.chargetyp,
-                "COLORTEXT": self.colortext, "COLORBAR": self.colorbar, "COLORBK": self.colorbk}
-
-
-class Workplace(Base):
-    __tablename__ = "workplaces"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(100), nullable=False)
-    shortname: Mapped[str | None] = mapped_column(String(20), default="")
-    position: Mapped[int] = mapped_column(Integer, default=0)
-    hide: Mapped[bool] = mapped_column(Boolean, default=False)
-    colortext: Mapped[int] = mapped_column(Integer, default=0)
-    colorbar: Mapped[int] = mapped_column(Integer, default=0)
-    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
-
-    def to_dict(self) -> dict:
-        return {"ID": self.id, "NAME": self.name, "SHORTNAME": self.shortname or "",
-                "POSITION": self.position, "HIDE": self.hide,
-                "COLORTEXT": self.colortext, "COLORBAR": self.colorbar, "COLORBK": self.colorbk}
+# Shift / LeaveType / Workplace are defined canonically in models.py (single
+# source of truth for the SQLite + Postgres schema) and re-exported here so
+# existing `from sp5lib.orm.models_pg import Shift, LeaveType, Workplace`
+# imports keep working unchanged.
+from .models import LeaveType, Shift, Workplace  # noqa: F401,E402
 
 
 class Holiday(Base):

--- a/sp5lib/orm/repository.py
+++ b/sp5lib/orm/repository.py
@@ -13,7 +13,7 @@ writes raw SQL, so a database migration is a config change, not a rewrite.
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .models import Employee, Group, GroupAssignment
+from .models import Employee, Group, GroupAssignment, LeaveType, Shift, Workplace
 
 
 class EmployeeRepository:
@@ -183,3 +183,57 @@ class GroupRepository:
             .order_by(Group.position)
         )
         return list(self.session.scalars(stmt).all())
+
+
+class ShiftRepository:
+    """Data access for Shift definitions (5SHIFT.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(self, include_hidden: bool = False) -> list[Shift]:
+        """Return all shifts, ordered by position."""
+        stmt = select(Shift).order_by(Shift.position)
+        if not include_hidden:
+            stmt = stmt.where(Shift.hide == False)  # noqa: E712
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, shift_id: int) -> Shift | None:
+        """Return a single shift by ID, or None."""
+        return self.session.get(Shift, shift_id)
+
+
+class LeaveTypeRepository:
+    """Data access for LeaveType definitions (5LEAVT.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(self, include_hidden: bool = False) -> list[LeaveType]:
+        """Return all leave types, ordered by position."""
+        stmt = select(LeaveType).order_by(LeaveType.position)
+        if not include_hidden:
+            stmt = stmt.where(LeaveType.hide == False)  # noqa: E712
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, leave_type_id: int) -> LeaveType | None:
+        """Return a single leave type by ID, or None."""
+        return self.session.get(LeaveType, leave_type_id)
+
+
+class WorkplaceRepository:
+    """Data access for Workplace definitions (5WOPL.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(self, include_hidden: bool = False) -> list[Workplace]:
+        """Return all workplaces, ordered by position."""
+        stmt = select(Workplace).order_by(Workplace.position)
+        if not include_hidden:
+            stmt = stmt.where(Workplace.hide == False)  # noqa: E712
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, workplace_id: int) -> Workplace | None:
+        """Return a single workplace by ID, or None."""
+        return self.session.get(Workplace, workplace_id)

--- a/sp5lib/orm/sync.py
+++ b/sp5lib/orm/sync.py
@@ -20,7 +20,14 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from .base import get_session
-from .models import Employee, Group, GroupAssignment
+from .models import (
+    Employee,
+    Group,
+    GroupAssignment,
+    LeaveType,
+    Shift,
+    Workplace,
+)
 
 _log = logging.getLogger("sp5api.orm.sync")
 
@@ -139,6 +146,96 @@ def sync_group_assignments(session: Session, daten_path: str) -> int:
     return count
 
 
+def sync_shifts(session: Session, daten_path: str) -> int:
+    """Sync shift definitions from 5SHIFT.DBF into the ORM shifts table."""
+    rows = _read_dbf(daten_path, "SHIFT")
+    count = 0
+
+    for r in rows:
+        shift_id = r.get("ID")
+        if not shift_id:
+            continue
+
+        shift = session.get(Shift, shift_id)
+        if shift is None:
+            shift = Shift(id=shift_id)
+            session.add(shift)
+
+        shift.name = str(r.get("NAME") or "").strip()
+        shift.shortname = str(r.get("SHORTNAME") or "").strip()
+        shift.position = r.get("POSITION", 0) or 0
+        shift.hide = bool(r.get("HIDE"))
+        shift.colortext = r.get("COLORTEXT", 0) or 0
+        shift.colorbar = r.get("COLORBAR", 0) or 0
+        shift.colorbk = r.get("COLORBK", 16777215) or 16777215
+        for i in range(8):
+            setattr(shift, f"duration{i}", float(r.get(f"DURATION{i}", 0) or 0))
+            setattr(shift, f"startend{i}", str(r.get(f"STARTEND{i}") or "").strip())
+        count += 1
+
+    session.flush()
+    return count
+
+
+def sync_leave_types(session: Session, daten_path: str) -> int:
+    """Sync leave/absence types from 5LEAVT.DBF into the ORM leave_types table."""
+    rows = _read_dbf(daten_path, "LEAVT")
+    count = 0
+
+    for r in rows:
+        lt_id = r.get("ID")
+        if not lt_id:
+            continue
+
+        lt = session.get(LeaveType, lt_id)
+        if lt is None:
+            lt = LeaveType(id=lt_id)
+            session.add(lt)
+
+        lt.name = str(r.get("NAME") or "").strip()
+        lt.shortname = str(r.get("SHORTNAME") or "").strip()
+        lt.position = r.get("POSITION", 0) or 0
+        lt.hide = bool(r.get("HIDE"))
+        lt.entitled = bool(r.get("ENTITLED"))
+        lt.stdentit = float(r.get("STDENTIT", 0) or 0)
+        lt.chargetyp = r.get("CHARGETYP", 0) or 0
+        lt.colortext = r.get("COLORTEXT", 0) or 0
+        lt.colorbar = r.get("COLORBAR", 0) or 0
+        lt.colorbk = r.get("COLORBK", 16777215) or 16777215
+        count += 1
+
+    session.flush()
+    return count
+
+
+def sync_workplaces(session: Session, daten_path: str) -> int:
+    """Sync workplace definitions from 5WOPL.DBF into the ORM workplaces table."""
+    rows = _read_dbf(daten_path, "WOPL")
+    count = 0
+
+    for r in rows:
+        wp_id = r.get("ID")
+        if not wp_id:
+            continue
+
+        wp = session.get(Workplace, wp_id)
+        if wp is None:
+            wp = Workplace(id=wp_id)
+            session.add(wp)
+
+        wp.name = str(r.get("NAME") or "").strip()
+        wp.shortname = str(r.get("SHORTNAME") or "").strip()
+        wp.position = r.get("POSITION", 0) or 0
+        wp.hide = bool(r.get("HIDE"))
+        wp.colortext = r.get("COLORTEXT", 0) or 0
+        wp.colorbar = r.get("COLORBAR", 0) or 0
+        wp.colorbk = r.get("COLORBK", 16777215) or 16777215
+        count += 1
+
+    session.flush()
+    return count
+
+
 def sync_all(engine, daten_path: str) -> dict[str, int]:
     """Sync all supported tables from DBF into the ORM database.
 
@@ -150,6 +247,9 @@ def sync_all(engine, daten_path: str) -> dict[str, int]:
         stats["employees"] = sync_employees(session, daten_path)
         stats["groups"] = sync_groups(session, daten_path)
         stats["group_assignments"] = sync_group_assignments(session, daten_path)
+        stats["shifts"] = sync_shifts(session, daten_path)
+        stats["leave_types"] = sync_leave_types(session, daten_path)
+        stats["workplaces"] = sync_workplaces(session, daten_path)
         session.commit()
         _log.info("ORM sync complete: %s", stats)
         return stats

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,0 +1,228 @@
+"""Tests for the Phase-2 ORM models, repositories and DBF sync.
+
+These run entirely against an in-memory SQLite database (no external
+fixtures), mirroring the self-contained style of test_dbf.py. They cover the
+Shift / LeaveType / Workplace models added in Phase 2: schema creation via
+init_db, repository list/get semantics, to_dict() shape, and the DBF -> ORM
+upsert in sync.py (with _read_dbf patched to canned rows).
+"""
+
+import pytest
+
+from sp5lib.orm import (
+    LeaveType,
+    LeaveTypeRepository,
+    Shift,
+    ShiftRepository,
+    Workplace,
+    WorkplaceRepository,
+    get_engine,
+    init_db,
+)
+from sp5lib.orm.base import session_scope
+
+
+@pytest.fixture
+def engine():
+    """Fresh in-memory SQLite engine with all ORM tables created."""
+    eng = get_engine("sqlite:///:memory:")
+    init_db(eng)
+    return eng
+
+
+# ─── schema / importability ───────────────────────────────────────────────────
+
+
+def test_init_db_creates_phase2_tables(engine):
+    from sqlalchemy import inspect
+
+    tables = set(inspect(engine).get_table_names())
+    assert {"shifts", "leave_types", "workplaces"} <= tables
+
+
+def test_models_reexported_from_models_pg_are_identical():
+    # Single source of truth: models_pg re-exports the canonical classes.
+    from sp5lib.orm import models, models_pg
+
+    assert models.Shift is models_pg.Shift
+    assert models.LeaveType is models_pg.LeaveType
+    assert models.Workplace is models_pg.Workplace
+
+
+# ─── repositories: list() / get() ───────────────────────────────────────────────
+
+
+def test_shift_repository_list_orders_by_position_and_hides(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                Shift(id=1, name="Spät", position=2),
+                Shift(id=2, name="Früh", position=1),
+                Shift(id=3, name="Alt", position=3, hide=True),
+            ]
+        )
+        session.flush()
+        repo = ShiftRepository(session)
+
+        visible = repo.list()
+        assert [s.id for s in visible] == [2, 1]  # ordered by position, hidden excluded
+
+        all_shifts = repo.list(include_hidden=True)
+        assert [s.id for s in all_shifts] == [2, 1, 3]
+
+
+def test_shift_repository_get(engine):
+    with session_scope(engine) as session:
+        session.add(Shift(id=5, name="Nacht"))
+        session.flush()
+        repo = ShiftRepository(session)
+        assert repo.get(5).name == "Nacht"
+        assert repo.get(999) is None
+
+
+def test_leave_type_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                LeaveType(id=1, name="Urlaub", position=1),
+                LeaveType(id=2, name="Krank", position=2, hide=True),
+            ]
+        )
+        session.flush()
+        repo = LeaveTypeRepository(session)
+        assert [lt.id for lt in repo.list()] == [1]
+        assert [lt.id for lt in repo.list(include_hidden=True)] == [1, 2]
+        assert repo.get(1).name == "Urlaub"
+        assert repo.get(2) is None or repo.get(2).name == "Krank"
+
+
+def test_workplace_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                Workplace(id=1, name="Empfang", position=2),
+                Workplace(id=2, name="Lager", position=1),
+            ]
+        )
+        session.flush()
+        repo = WorkplaceRepository(session)
+        assert [w.id for w in repo.list()] == [2, 1]
+        assert repo.get(2).name == "Lager"
+        assert repo.get(404) is None
+
+
+# ─── to_dict() shape ────────────────────────────────────────────────────────────
+
+
+def test_shift_to_dict_shape():
+    d = Shift(id=1, name="Früh", shortname="F", duration0=8.0, startend0="08:00-16:00").to_dict()
+    assert d["ID"] == 1
+    assert d["NAME"] == "Früh"
+    assert d["SHORTNAME"] == "F"
+    assert d["DURATION0"] == 8.0
+    assert d["STARTEND0"] == "08:00-16:00"
+    # all eight weekday slots are present
+    assert all(f"DURATION{i}" in d and f"STARTEND{i}" in d for i in range(8))
+
+
+def test_leave_type_to_dict_shape():
+    d = LeaveType(id=2, name="Urlaub", entitled=True, stdentit=30.0).to_dict()
+    assert d["ID"] == 2 and d["NAME"] == "Urlaub"
+    assert d["ENTITLED"] is True and d["STDENTIT"] == 30.0
+    assert {"COLORTEXT", "COLORBAR", "COLORBK"} <= d.keys()
+
+
+def test_workplace_to_dict_shape(engine):
+    # Column defaults (position/hide/colors) are applied by SQLAlchemy on flush,
+    # so build the row through a session to assert the full defaulted dict.
+    with session_scope(engine) as session:
+        session.add(Workplace(id=3, name="Lager", shortname="LG"))
+        session.flush()
+        d = WorkplaceRepository(session).get(3).to_dict()
+    assert d == {
+        "ID": 3,
+        "NAME": "Lager",
+        "SHORTNAME": "LG",
+        "POSITION": 0,
+        "HIDE": False,
+        "COLORTEXT": 0,
+        "COLORBAR": 0,
+        "COLORBK": 16777215,
+    }
+
+
+# ─── sync.py: DBF -> ORM upsert (with _read_dbf patched) ─────────────────────────
+
+
+def _patch_dbf(monkeypatch, table_rows):
+    """Patch sync._read_dbf to serve canned rows keyed by DBF table name."""
+    from sp5lib.orm import sync
+
+    def fake_read(_daten_path, table_name):
+        return table_rows.get(table_name, [])
+
+    monkeypatch.setattr(sync, "_read_dbf", fake_read)
+
+
+def test_sync_shifts_insert_and_update(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"SHIFT": [{"ID": 1, "NAME": "Früh", "SHORTNAME": "F", "POSITION": 1,
+                    "DURATION0": 8.0, "STARTEND0": "08:00-16:00", "COLORBK": 100}]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_shifts(session, "/x") == 1
+        s = ShiftRepository(session).get(1)
+        assert s.name == "Früh" and s.duration0 == 8.0 and s.colorbk == 100
+
+    # second run with changed data updates the same row (upsert, no duplicate)
+    _patch_dbf(monkeypatch, {"SHIFT": [{"ID": 1, "NAME": "Frühdienst", "POSITION": 1}]})
+    with session_scope(engine) as session:
+        assert sync.sync_shifts(session, "/x") == 1
+        repo = ShiftRepository(session)
+        assert repo.get(1).name == "Frühdienst"
+        assert len(repo.list(include_hidden=True)) == 1
+
+
+def test_sync_leave_types_and_workplaces(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "LEAVT": [{"ID": 1, "NAME": "Urlaub", "ENTITLED": True, "STDENTIT": 30.0}],
+            "WOPL": [{"ID": 1, "NAME": "Empfang", "SHORTNAME": "EMP"}],
+        },
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_leave_types(session, "/x") == 1
+        assert sync.sync_workplaces(session, "/x") == 1
+        assert LeaveTypeRepository(session).get(1).entitled is True
+        assert WorkplaceRepository(session).get(1).shortname == "EMP"
+
+
+def test_sync_skips_rows_without_id(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(monkeypatch, {"WOPL": [{"ID": 0, "NAME": "ignored"}, {"NAME": "no-id"}]})
+    with session_scope(engine) as session:
+        assert sync.sync_workplaces(session, "/x") == 0
+
+
+def test_sync_all_includes_phase2_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "SHIFT": [{"ID": 1, "NAME": "Früh"}],
+            "LEAVT": [{"ID": 1, "NAME": "Urlaub"}],
+            "WOPL": [{"ID": 1, "NAME": "Empfang"}],
+        },
+    )
+    stats = sync.sync_all(engine, "/x")
+    assert stats["shifts"] == 1
+    assert stats["leave_types"] == 1
+    assert stats["workplaces"] == 1


### PR DESCRIPTION
Implements **from-app issue #3** — ORM Phase 2.

## What

Extends the SQLAlchemy ORM layer (`sp5lib.orm`) beyond Phase 1 (Employee/Group) with the next three core entities, mirroring the Phase 1 patterns.

- **Models** `Shift` (`5SHIFT.DBF`), `LeaveType` (`5LEAVT.DBF`), `Workplace` (`5WOPL.DBF`) — importable from `sp5lib.orm`; `init_db()` creates the `shifts` / `leave_types` / `workplaces` tables.
- **Repositories** `ShiftRepository`, `LeaveTypeRepository`, `WorkplaceRepository` with `list(include_hidden=False)` + `get(id)`.
- **Sync** `sync.sync_shifts` / `sync_leave_types` / `sync_workplaces` upsert DBF → ORM; `sync_all()` now also returns those three counts.
- **Tests** `tests/test_orm.py` (in-memory SQLite): models, repositories, `to_dict()`, and the sync upsert (insert + update, skip-without-id, `sync_all`).

## Design note (single source of truth)

`Shift`/`LeaveType`/`Workplace` already existed in `models_pg.py`. Since both `models.py` and `models_pg.py` register on the **same** `Base.metadata` and are both imported together by `pg_database.py`, defining them in both would collide. They are now defined **canonically in `models.py`** and **re-exported** from `models_pg.py`:

- `to_dict()` is therefore literally identical between SQLite/PG (issue: "don't widen the known divergence").
- `from sp5lib.orm.models_pg import Shift, LeaveType, Workplace` keeps working unchanged (used by `pg_database.py`).
- Field set is the existing rich superset — purely additive, no PG behaviour change.

## Acceptance criteria

- [x] New models importable from `sp5lib.orm`, unit-tested (in-memory SQLite)
- [x] `init_db()` creates the tables; `sync.py` upserts them
- [x] `ruff check .` + `pytest -v` green (27 passed locally)
- [x] Version bumped to **1.2.0** for the PyPI release (tag pushed after merge)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)