### PR TITLE
feat(orm): Phase 3 — schedule entries (MASHI/SPSHI/ABSEN) + sync_groups FK fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-27
+
+ORM Phase 3 — the time-based roster. Adds the schedule-entry tables to the
+SQLAlchemy layer plus a sync robustness fix. Additive and backward compatible.
+
+### Added
+
+- **`ShiftAssignment`** (`schedule_entries`, from `5MASHI.DBF`),
+  **`SpecialShift`** (`special_shifts`, `5SPSHI.DBF`) and **`Absence`**
+  (`absences`, `5ABSEN.DBF`) ORM models, importable from `sp5lib.orm`, each with
+  a `to_dict()` mirroring the DBF keys (`DATE` / `EMPLOYEEID` / `SHIFTID` /
+  `LEAVETYPID` / …). `init_db()` creates the tables.
+- **`ShiftAssignmentRepository`**, **`SpecialShiftRepository`**,
+  **`AbsenceRepository`** with `list(date_from=None, date_to=None,
+  employee_id=None)` (date-window + per-employee filtering) and `get(id)`.
+- DBF → ORM upsert `sync.sync_shift_assignments`, `sync.sync_special_shifts`,
+  `sync.sync_absences`, wired into `sync.sync_all()`. Blank/invalid `DATE`
+  values are skipped and logged; references (employee/shift/leave-type) are
+  plain indexed integers with no DB-level FK, so dirty legacy data syncs.
+
+### Fixed
+
+- `sync.sync_groups` no longer aborts `sync_all` with
+  `FOREIGN KEY constraint failed` when `5GROUP.DBF` contains a `super_id` that
+  points to a non-existent group. Dangling parent references are now resolved
+  in a second pass: unknown references are set to `NULL` and logged. This also
+  makes group ordering in the DBF irrelevant.
+
+### Changed
+
+- `ShiftAssignment`, `SpecialShift` and `Absence` are defined canonically in
+  `sp5lib.orm.models` and re-exported from `sp5lib.orm.models_pg`. The former
+  `ScheduleEntry` name (MASHI) remains importable as an alias of
+  `ShiftAssignment`, so existing
+  `from sp5lib.orm.models_pg import ScheduleEntry, SpecialShift, Absence`
+  imports (used by `pg_database`) keep working unchanged.
+
 ## [1.2.0] - 2026-05-27
 
 ORM Phase 2 — adds the next three core entities to the SQLAlchemy layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
-version = "1.2.0"
+version = "1.3.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/sp5lib/orm/README.md
+++ b/sp5lib/orm/README.md
@@ -34,8 +34,8 @@ layer and serves as a foundation for a future database migration (SQLite → Pos
 sp5lib/orm/
 ├── __init__.py       # Public API: get_engine, get_session, init_db
 ├── base.py           # Engine factory, session management, Base class
-├── models.py         # ORM models: Employee, Group, GroupAssignment, Shift, LeaveType, Workplace
-├── repository.py     # Repositories: Employee, Group, Shift, LeaveType, Workplace
+├── models.py         # ORM models: core + Shift/LeaveType/Workplace + ShiftAssignment/SpecialShift/Absence
+├── repository.py     # Repositories for all of the above (master-data + schedule)
 ├── sync.py           # DBF → ORM sync utilities
 └── README.md         # This file
 ```
@@ -85,7 +85,7 @@ This initial implementation covers:
 
 1. ✅ **Phase 1**: ORM models + repositories for Employees & Groups
 2. ✅ **Phase 2**: ORM models + repositories + DBF sync for Shifts, LeaveTypes, Workplaces
-3. **Phase 3**: Add models for Schedule entries (MASHI, SPSHI, ABSEN)
+3. ✅ **Phase 3**: ORM models + repositories + DBF sync for Schedule entries (MASHI → ShiftAssignment, SPSHI → SpecialShift, ABSEN → Absence)
 4. **Phase 4**: Wire ORM repositories into FastAPI routers (dual-read)
 5. **Phase 5**: Switch write path to ORM, keep DBF sync for legacy
 6. **Phase 6**: Drop DBF dependency, run on PostgreSQL

--- a/sp5lib/orm/__init__.py
+++ b/sp5lib/orm/__init__.py
@@ -19,21 +19,30 @@ Usage:
 
 from .base import Base, get_engine, get_session, init_db
 from .models import (
+    Absence,
     Company,
     Employee,
     Group,
     GroupAssignment,
     LeaveType,
     Shift,
+    ShiftAssignment,
+    SpecialShift,
     Workplace,
 )
 from .repository import (
+    AbsenceRepository,
     EmployeeRepository,
     GroupRepository,
     LeaveTypeRepository,
+    ShiftAssignmentRepository,
     ShiftRepository,
+    SpecialShiftRepository,
     WorkplaceRepository,
 )
+
+# Legacy alias for the MASHI master-schedule model (now ShiftAssignment).
+ScheduleEntry = ShiftAssignment
 
 __all__ = [
     # Engine / session / schema
@@ -41,7 +50,7 @@ __all__ = [
     "get_engine",
     "get_session",
     "init_db",
-    # Models
+    # Master-data models
     "Company",
     "Employee",
     "Group",
@@ -49,10 +58,18 @@ __all__ = [
     "Shift",
     "LeaveType",
     "Workplace",
+    # Schedule (Phase 3) models
+    "ShiftAssignment",
+    "ScheduleEntry",
+    "SpecialShift",
+    "Absence",
     # Repositories
     "EmployeeRepository",
     "GroupRepository",
     "ShiftRepository",
     "LeaveTypeRepository",
     "WorkplaceRepository",
+    "ShiftAssignmentRepository",
+    "SpecialShiftRepository",
+    "AbsenceRepository",
 ]

--- a/sp5lib/orm/models.py
+++ b/sp5lib/orm/models.py
@@ -384,3 +384,126 @@ class Workplace(Base):
             "COLORBAR": self.colorbar,
             "COLORBK": self.colorbk,
         }
+
+
+# ── Phase 3: time-based schedule entries ─────────────────────────────────────
+# The actual roster (not just the master-data definitions). Foreign keys to
+# employees / shifts / leave types are modelled as plain indexed Integer
+# columns *without* DB-level FK constraints, so dirty legacy data (dangling
+# references) syncs without breaking. Defined canonically here and re-exported
+# from models_pg.py (ShiftAssignment is also aliased there as ScheduleEntry).
+
+
+class ShiftAssignment(Base):
+    """Regular shift assignment (Dienstplan-Eintrag) — maps to 5MASHI.DBF."""
+
+    __tablename__ = "schedule_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    shift_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
+    entry_type: Mapped[int] = mapped_column(Integer, default=0)
+
+    __table_args__ = (
+        Index("idx_schedule_emp_date", "employee_id", "date"),
+        Index("idx_schedule_date", "date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ShiftAssignment(id={self.id}, emp={self.employee_id}, date='{self.date}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "DATE": self.date,
+            "EMPLOYEEID": self.employee_id,
+            "SHIFTID": self.shift_id,
+            "WORKPLACID": self.workplace_id,
+            "TYPE": self.entry_type,
+        }
+
+
+class SpecialShift(Base):
+    """Special / one-off shift (Sonderschicht) — maps to 5SPSHI.DBF."""
+
+    __tablename__ = "special_shifts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    name: Mapped[str | None] = mapped_column(String(100), default="")
+    shortname: Mapped[str | None] = mapped_column(String(20), default="")
+    shift_id: Mapped[int] = mapped_column(Integer, default=0)
+    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
+    entry_type: Mapped[int] = mapped_column(Integer, default=0)
+    colortext: Mapped[int] = mapped_column(Integer, default=0)
+    colorbar: Mapped[int] = mapped_column(Integer, default=0)
+    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
+    bold: Mapped[int] = mapped_column(Integer, default=0)
+    startend: Mapped[str | None] = mapped_column(String(50), default="")
+    duration: Mapped[float] = mapped_column(Float, default=0.0)
+    noextra: Mapped[int] = mapped_column(Integer, default=0)
+
+    __table_args__ = (
+        Index("idx_spshi_emp_date", "employee_id", "date"),
+        Index("idx_spshi_date", "date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SpecialShift(id={self.id}, emp={self.employee_id}, date='{self.date}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "DATE": self.date,
+            "EMPLOYEEID": self.employee_id,
+            "SHIFTID": self.shift_id,
+            "WORKPLACID": self.workplace_id,
+            "TYPE": self.entry_type,
+            "NAME": self.name or "",
+            "SHORTNAME": self.shortname or "",
+            "COLORTEXT": self.colortext,
+            "COLORBAR": self.colorbar,
+            "COLORBK": self.colorbk,
+            "BOLD": self.bold,
+            "STARTEND": self.startend or "",
+            "DURATION": self.duration,
+            "NOEXTRA": self.noextra,
+        }
+
+
+class Absence(Base):
+    """Absence / leave entry (Abwesenheit) — maps to 5ABSEN.DBF."""
+
+    __tablename__ = "absences"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    leave_type_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    entry_type: Mapped[int] = mapped_column(Integer, default=0)
+    interval: Mapped[int] = mapped_column(Integer, default=0)
+    start: Mapped[int] = mapped_column(Integer, default=0)
+    end: Mapped[int] = mapped_column(Integer, default=0)
+
+    __table_args__ = (
+        Index("idx_absence_emp_date", "employee_id", "date"),
+        Index("idx_absence_date", "date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Absence(id={self.id}, emp={self.employee_id}, date='{self.date}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "DATE": self.date,
+            "EMPLOYEEID": self.employee_id,
+            "LEAVETYPID": self.leave_type_id,
+            "TYPE": self.entry_type,
+            "INTERVAL": self.interval,
+            "START": self.start,
+            "END": self.end,
+        }

--- a/sp5lib/orm/models_pg.py
+++ b/sp5lib/orm/models_pg.py
@@ -9,7 +9,6 @@ models already defined in models.py.
 from sqlalchemy import (
     Boolean,
     Float,
-    Index,
     Integer,
     LargeBinary,
     String,
@@ -19,11 +18,23 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
-# Shift / LeaveType / Workplace are defined canonically in models.py (single
-# source of truth for the SQLite + Postgres schema) and re-exported here so
-# existing `from sp5lib.orm.models_pg import Shift, LeaveType, Workplace`
-# imports keep working unchanged.
-from .models import LeaveType, Shift, Workplace  # noqa: F401,E402
+# Master-data (Phase 2) and schedule (Phase 3) entities are defined canonically
+# in models.py (single source of truth for the SQLite + Postgres schema) and
+# re-exported here so existing `from sp5lib.orm.models_pg import …` imports keep
+# working unchanged. ScheduleEntry is the legacy name for ShiftAssignment.
+from .models import (  # noqa: F401,E402
+    Absence,
+    LeaveType,
+    Shift,
+    ShiftAssignment,
+    SpecialShift,
+    Workplace,
+)
+
+# Backward-compatible alias: the MASHI master-schedule model was previously
+# called ScheduleEntry. It is now ShiftAssignment (same table "schedule_entries",
+# same columns); keep the old name importable for existing consumers.
+ScheduleEntry = ShiftAssignment
 
 
 class Holiday(Base):
@@ -35,50 +46,6 @@ class Holiday(Base):
 
     def to_dict(self) -> dict:
         return {"ID": self.id, "DATE": self.date, "NAME": self.name, "INTERVAL": self.interval}
-
-
-class ScheduleEntry(Base):
-    __tablename__ = "schedule_entries"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    shift_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
-    entry_type: Mapped[int] = mapped_column(Integer, default=0)
-    __table_args__ = (Index("idx_schedule_emp_date", "employee_id", "date"), Index("idx_schedule_date", "date"))
-
-
-class SpecialShift(Base):
-    __tablename__ = "special_shifts"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    name: Mapped[str | None] = mapped_column(String(100), default="")
-    shortname: Mapped[str | None] = mapped_column(String(20), default="")
-    shift_id: Mapped[int] = mapped_column(Integer, default=0)
-    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
-    entry_type: Mapped[int] = mapped_column(Integer, default=0)
-    colortext: Mapped[int] = mapped_column(Integer, default=0)
-    colorbar: Mapped[int] = mapped_column(Integer, default=0)
-    colorbk: Mapped[int] = mapped_column(Integer, default=16777215)
-    bold: Mapped[int] = mapped_column(Integer, default=0)
-    startend: Mapped[str | None] = mapped_column(String(50), default="")
-    duration: Mapped[float] = mapped_column(Float, default=0.0)
-    noextra: Mapped[int] = mapped_column(Integer, default=0)
-    __table_args__ = (Index("idx_spshi_emp_date", "employee_id", "date"), Index("idx_spshi_date", "date"))
-
-
-class Absence(Base):
-    __tablename__ = "absences"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    leave_type_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    entry_type: Mapped[int] = mapped_column(Integer, default=0)
-    interval: Mapped[int] = mapped_column(Integer, default=0)
-    start: Mapped[int] = mapped_column(Integer, default=0)
-    end: Mapped[int] = mapped_column(Integer, default=0)
-    __table_args__ = (Index("idx_absence_emp_date", "employee_id", "date"), Index("idx_absence_date", "date"))
 
 
 class User(Base):

--- a/sp5lib/orm/repository.py
+++ b/sp5lib/orm/repository.py
@@ -13,7 +13,17 @@ writes raw SQL, so a database migration is a config change, not a rewrite.
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .models import Employee, Group, GroupAssignment, LeaveType, Shift, Workplace
+from .models import (
+    Absence,
+    Employee,
+    Group,
+    GroupAssignment,
+    LeaveType,
+    Shift,
+    ShiftAssignment,
+    SpecialShift,
+    Workplace,
+)
 
 
 class EmployeeRepository:
@@ -237,3 +247,87 @@ class WorkplaceRepository:
     def get(self, workplace_id: int) -> Workplace | None:
         """Return a single workplace by ID, or None."""
         return self.session.get(Workplace, workplace_id)
+
+
+class ShiftAssignmentRepository:
+    """Data access for regular schedule entries (5MASHI.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        employee_id: int | None = None,
+    ) -> list[ShiftAssignment]:
+        """Return schedule entries filtered by ISO date range and/or employee."""
+        stmt = select(ShiftAssignment)
+        if date_from is not None:
+            stmt = stmt.where(ShiftAssignment.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(ShiftAssignment.date <= date_to)
+        if employee_id is not None:
+            stmt = stmt.where(ShiftAssignment.employee_id == employee_id)
+        stmt = stmt.order_by(ShiftAssignment.date, ShiftAssignment.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, entry_id: int) -> ShiftAssignment | None:
+        """Return a single schedule entry by ID, or None."""
+        return self.session.get(ShiftAssignment, entry_id)
+
+
+class SpecialShiftRepository:
+    """Data access for special / one-off shifts (5SPSHI.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        employee_id: int | None = None,
+    ) -> list[SpecialShift]:
+        """Return special shifts filtered by ISO date range and/or employee."""
+        stmt = select(SpecialShift)
+        if date_from is not None:
+            stmt = stmt.where(SpecialShift.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(SpecialShift.date <= date_to)
+        if employee_id is not None:
+            stmt = stmt.where(SpecialShift.employee_id == employee_id)
+        stmt = stmt.order_by(SpecialShift.date, SpecialShift.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, entry_id: int) -> SpecialShift | None:
+        """Return a single special shift by ID, or None."""
+        return self.session.get(SpecialShift, entry_id)
+
+
+class AbsenceRepository:
+    """Data access for absences / leave entries (5ABSEN.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        employee_id: int | None = None,
+    ) -> list[Absence]:
+        """Return absences filtered by ISO date range and/or employee."""
+        stmt = select(Absence)
+        if date_from is not None:
+            stmt = stmt.where(Absence.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(Absence.date <= date_to)
+        if employee_id is not None:
+            stmt = stmt.where(Absence.employee_id == employee_id)
+        stmt = stmt.order_by(Absence.date, Absence.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, entry_id: int) -> Absence | None:
+        """Return a single absence by ID, or None."""
+        return self.session.get(Absence, entry_id)

--- a/sp5lib/orm/sync.py
+++ b/sp5lib/orm/sync.py
@@ -17,15 +17,19 @@ Usage:
 import logging
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from .base import get_session
 from .models import (
+    Absence,
     Employee,
     Group,
     GroupAssignment,
     LeaveType,
     Shift,
+    ShiftAssignment,
+    SpecialShift,
     Workplace,
 )
 
@@ -44,6 +48,21 @@ def _read_dbf(daten_path: str, table_name: str) -> list[dict[str, Any]]:
     except Exception as exc:
         _log.warning("Could not read %s: %s", path, exc)
         return []
+
+
+def _valid_date(value: Any) -> str | None:
+    """Return a normalised ISO date string, or None for empty/invalid input.
+
+    read_dbf already parses DBF 'D' fields to 'YYYY-MM-DD' (or None for invalid
+    calendar dates). This guards the schedule sync against blank/garbage dates.
+    """
+    if not value:
+        return None
+    s = str(value).strip()
+    # Expect ISO 'YYYY-MM-DD'; reject anything that is not a plausible date.
+    if len(s) != 10 or s[4] != "-" or s[7] != "-":
+        return None
+    return s
 
 
 def sync_employees(session: Session, daten_path: str) -> int:
@@ -97,10 +116,19 @@ def sync_employees(session: Session, daten_path: str) -> int:
 
 
 def sync_groups(session: Session, daten_path: str) -> int:
-    """Sync groups from 5GROUP.DBF into the ORM groups table."""
+    """Sync groups from 5GROUP.DBF into the ORM groups table.
+
+    ``super_id`` (the self-referential parent FK) is resolved in a second pass
+    against the full set of known group IDs. A reference to a group that does
+    not exist (dangling reference in dirty legacy data) is set to NULL and
+    logged, instead of raising ``FOREIGN KEY constraint failed`` and aborting
+    the whole sync. The two-pass approach also makes ordering irrelevant
+    (parents may appear after their children in the DBF).
+    """
     rows = _read_dbf(daten_path, "GROUP")
     count = 0
 
+    # Pass 1: upsert scalar columns; defer super_id until all groups exist.
     for r in rows:
         group_id = r.get("ID")
         if not group_id:
@@ -113,10 +141,30 @@ def sync_groups(session: Session, daten_path: str) -> int:
 
         group.name = str(r.get("NAME") or "").strip()
         group.shortname = str(r.get("SHORTNAME") or "").strip()
-        group.super_id = r.get("SUPERID") or None
+        group.super_id = None
         group.position = r.get("POSITION", 0) or 0
         group.hide = bool(r.get("HIDE"))
         count += 1
+
+    session.flush()
+
+    # Pass 2: resolve super_id against the now-complete set of group IDs.
+    valid_ids = set(session.scalars(select(Group.id)).all())
+    for r in rows:
+        group_id = r.get("ID")
+        if not group_id:
+            continue
+        super_id = r.get("SUPERID") or None
+        if super_id and super_id not in valid_ids:
+            _log.warning(
+                "group %s references missing super_id %s — setting NULL",
+                group_id,
+                super_id,
+            )
+            super_id = None
+        if super_id:
+            group = session.get(Group, group_id)
+            group.super_id = super_id
 
     session.flush()
     return count
@@ -236,6 +284,122 @@ def sync_workplaces(session: Session, daten_path: str) -> int:
     return count
 
 
+def sync_shift_assignments(session: Session, daten_path: str) -> int:
+    """Sync regular schedule entries from 5MASHI.DBF.
+
+    Rows with a blank/invalid DATE are skipped and logged. employee_id /
+    shift_id / workplace_id are stored as plain integers (no FK constraint),
+    so dangling references in dirty data do not break the sync.
+    """
+    rows = _read_dbf(daten_path, "MASHI")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        entry_id = r.get("ID")
+        if not entry_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        entry = session.get(ShiftAssignment, entry_id)
+        if entry is None:
+            entry = ShiftAssignment(id=entry_id)
+            session.add(entry)
+
+        entry.date = date
+        entry.employee_id = r.get("EMPLOYEEID", 0) or 0
+        entry.shift_id = r.get("SHIFTID", 0) or 0
+        entry.workplace_id = r.get("WORKPLACID", 0) or 0
+        entry.entry_type = r.get("TYPE", 0) or 0
+        count += 1
+
+    if skipped:
+        _log.warning("sync_shift_assignments: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_special_shifts(session: Session, daten_path: str) -> int:
+    """Sync special / one-off shifts from 5SPSHI.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "SPSHI")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        entry_id = r.get("ID")
+        if not entry_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        sp = session.get(SpecialShift, entry_id)
+        if sp is None:
+            sp = SpecialShift(id=entry_id)
+            session.add(sp)
+
+        sp.date = date
+        sp.employee_id = r.get("EMPLOYEEID", 0) or 0
+        sp.name = str(r.get("NAME") or "").strip()
+        sp.shortname = str(r.get("SHORTNAME") or "").strip()
+        sp.shift_id = r.get("SHIFTID", 0) or 0
+        sp.workplace_id = r.get("WORKPLACID", 0) or 0
+        sp.entry_type = r.get("TYPE", 0) or 0
+        sp.colortext = r.get("COLORTEXT", 0) or 0
+        sp.colorbar = r.get("COLORBAR", 0) or 0
+        sp.colorbk = r.get("COLORBK", 16777215) or 16777215
+        sp.bold = r.get("BOLD", 0) or 0
+        sp.startend = str(r.get("STARTEND") or "").strip()
+        sp.duration = float(r.get("DURATION", 0) or 0)
+        sp.noextra = r.get("NOEXTRA", 0) or 0
+        count += 1
+
+    if skipped:
+        _log.warning("sync_special_shifts: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_absences(session: Session, daten_path: str) -> int:
+    """Sync absences from 5ABSEN.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "ABSEN")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        entry_id = r.get("ID")
+        if not entry_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        ab = session.get(Absence, entry_id)
+        if ab is None:
+            ab = Absence(id=entry_id)
+            session.add(ab)
+
+        ab.date = date
+        ab.employee_id = r.get("EMPLOYEEID", 0) or 0
+        # DBF uses LEAVETYPID; tolerate the LEAVETYPEID spelling too.
+        ab.leave_type_id = r.get("LEAVETYPID") or r.get("LEAVETYPEID") or 0
+        ab.entry_type = r.get("TYPE", 0) or 0
+        ab.interval = r.get("INTERVAL", 0) or 0
+        ab.start = r.get("START", 0) or 0
+        ab.end = r.get("END", 0) or 0
+        count += 1
+
+    if skipped:
+        _log.warning("sync_absences: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
 def sync_all(engine, daten_path: str) -> dict[str, int]:
     """Sync all supported tables from DBF into the ORM database.
 
@@ -250,6 +414,9 @@ def sync_all(engine, daten_path: str) -> dict[str, int]:
         stats["shifts"] = sync_shifts(session, daten_path)
         stats["leave_types"] = sync_leave_types(session, daten_path)
         stats["workplaces"] = sync_workplaces(session, daten_path)
+        stats["shift_assignments"] = sync_shift_assignments(session, daten_path)
+        stats["special_shifts"] = sync_special_shifts(session, daten_path)
+        stats["absences"] = sync_absences(session, daten_path)
         session.commit()
         _log.info("ORM sync complete: %s", stats)
         return stats

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,19 +1,30 @@
-"""Tests for the Phase-2 ORM models, repositories and DBF sync.
+"""Tests for the Phase-2 / Phase-3 ORM models, repositories and DBF sync.
 
 These run entirely against an in-memory SQLite database (no external
-fixtures), mirroring the self-contained style of test_dbf.py. They cover the
-Shift / LeaveType / Workplace models added in Phase 2: schema creation via
-init_db, repository list/get semantics, to_dict() shape, and the DBF -> ORM
-upsert in sync.py (with _read_dbf patched to canned rows).
+fixtures), mirroring the self-contained style of test_dbf.py. They cover:
+- Phase 2: Shift / LeaveType / Workplace models, repositories, to_dict().
+- Phase 3: ShiftAssignment (MASHI) / SpecialShift (SPSHI) / Absence (ABSEN)
+  models, date-range repositories, and the schedule sync (invalid dates
+  skipped, FK-tolerant integer references).
+- The sync_groups dangling super_id fix (dangling parent -> NULL, no abort).
+DBF reads are exercised via _read_dbf patched to canned rows.
 """
 
 import pytest
 
 from sp5lib.orm import (
+    Absence,
+    AbsenceRepository,
+    Group,
     LeaveType,
     LeaveTypeRepository,
+    ScheduleEntry,
     Shift,
+    ShiftAssignment,
+    ShiftAssignmentRepository,
     ShiftRepository,
+    SpecialShift,
+    SpecialShiftRepository,
     Workplace,
     WorkplaceRepository,
     get_engine,
@@ -226,3 +237,165 @@ def test_sync_all_includes_phase2_tables(engine, monkeypatch):
     assert stats["shifts"] == 1
     assert stats["leave_types"] == 1
     assert stats["workplaces"] == 1
+
+
+# ─── Phase 3: schedule models / repositories ────────────────────────────────────
+
+
+def test_init_db_creates_phase3_tables(engine):
+    from sqlalchemy import inspect
+
+    tables = set(inspect(engine).get_table_names())
+    assert {"schedule_entries", "special_shifts", "absences"} <= tables
+
+
+def test_schedule_entry_is_alias_of_shift_assignment():
+    from sp5lib.orm import models, models_pg
+
+    assert ScheduleEntry is ShiftAssignment
+    assert models_pg.ScheduleEntry is ShiftAssignment
+    assert models_pg.SpecialShift is models.SpecialShift
+    assert models_pg.Absence is models.Absence
+
+
+def test_shift_assignment_repository_date_and_employee_filter(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                ShiftAssignment(id=1, employee_id=10, date="2026-01-05", shift_id=1),
+                ShiftAssignment(id=2, employee_id=10, date="2026-01-20", shift_id=2),
+                ShiftAssignment(id=3, employee_id=20, date="2026-01-10", shift_id=1),
+                ShiftAssignment(id=4, employee_id=10, date="2026-02-01", shift_id=1),
+            ]
+        )
+        session.flush()
+        repo = ShiftAssignmentRepository(session)
+
+        # full range ordered by date
+        assert [e.id for e in repo.list()] == [1, 3, 2, 4]
+        # date window (inclusive)
+        assert [e.id for e in repo.list(date_from="2026-01-01", date_to="2026-01-31")] == [1, 3, 2]
+        # employee filter
+        assert [e.id for e in repo.list(employee_id=10)] == [1, 2, 4]
+        # combined
+        assert [
+            e.id
+            for e in repo.list(date_from="2026-01-01", date_to="2026-01-31", employee_id=10)
+        ] == [1, 2]
+        assert repo.get(3).employee_id == 20
+        assert repo.get(99) is None
+
+
+def test_special_shift_and_absence_repositories(engine):
+    with session_scope(engine) as session:
+        session.add(SpecialShift(id=1, employee_id=10, date="2026-03-01", name="Extra"))
+        session.add(Absence(id=1, employee_id=10, date="2026-03-02", leave_type_id=5))
+        session.flush()
+        assert SpecialShiftRepository(session).list(employee_id=10)[0].name == "Extra"
+        assert AbsenceRepository(session).get(1).leave_type_id == 5
+        assert AbsenceRepository(session).list(date_from="2026-03-02")[0].id == 1
+        assert AbsenceRepository(session).list(date_to="2026-03-01") == []
+
+
+def test_shift_assignment_to_dict_mirrors_dbf_keys():
+    d = ShiftAssignment(id=7, employee_id=10, date="2026-01-05", shift_id=3,
+                        workplace_id=2, entry_type=1).to_dict()
+    assert d == {
+        "ID": 7, "DATE": "2026-01-05", "EMPLOYEEID": 10,
+        "SHIFTID": 3, "WORKPLACID": 2, "TYPE": 1,
+    }
+
+
+def test_absence_to_dict_mirrors_dbf_keys():
+    d = Absence(id=3, employee_id=10, date="2026-01-05", leave_type_id=5,
+                entry_type=0, interval=1, start=480, end=1020).to_dict()
+    assert d["LEAVETYPID"] == 5 and d["EMPLOYEEID"] == 10
+    assert d["START"] == 480 and d["END"] == 1020 and d["INTERVAL"] == 1
+
+
+# ─── Phase 3: schedule sync ─────────────────────────────────────────────────────
+
+
+def test_sync_shift_assignments_skips_invalid_dates(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"MASHI": [
+            {"ID": 1, "DATE": "2026-01-05", "EMPLOYEEID": 10, "SHIFTID": 1, "WORKPLACID": 2},
+            {"ID": 2, "DATE": "", "EMPLOYEEID": 10, "SHIFTID": 1},          # blank date
+            {"ID": 3, "DATE": "not-a-date", "EMPLOYEEID": 10, "SHIFTID": 1},  # garbage
+        ]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_shift_assignments(session, "/x") == 1
+        rows = ShiftAssignmentRepository(session).list()
+        assert [r.id for r in rows] == [1]
+        assert rows[0].workplace_id == 2
+
+
+def test_sync_absences_leavetype_spelling_tolerance(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"ABSEN": [
+            {"ID": 1, "DATE": "2026-01-05", "EMPLOYEEID": 10, "LEAVETYPID": 5},
+            {"ID": 2, "DATE": "2026-01-06", "EMPLOYEEID": 11, "LEAVETYPEID": 7},  # alt spelling
+        ]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_absences(session, "/x") == 2
+        repo = AbsenceRepository(session)
+        assert repo.get(1).leave_type_id == 5
+        assert repo.get(2).leave_type_id == 7
+
+
+def test_sync_schedule_tolerates_dangling_references(engine, monkeypatch):
+    # employee_id / shift_id are plain integers (no FK), so a row referencing a
+    # non-existent employee/shift must still sync without error.
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"SPSHI": [{"ID": 1, "DATE": "2026-01-05", "EMPLOYEEID": 9999, "SHIFTID": 8888}]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_special_shifts(session, "/x") == 1
+        assert SpecialShiftRepository(session).get(1).employee_id == 9999
+
+
+def test_sync_groups_dangling_super_id_set_null(engine, monkeypatch):
+    # Regression for the v1.2.0 defect: a super_id pointing at a missing group
+    # must be nulled (not raise FOREIGN KEY constraint failed and abort sync).
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"GROUP": [
+            {"ID": 1, "NAME": "Wurzel", "SUPERID": 0},
+            {"ID": 2, "NAME": "Kind", "SUPERID": 61},   # group 61 does not exist
+            {"ID": 3, "NAME": "Echt", "SUPERID": 1},    # valid parent
+        ]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_groups(session, "/x") == 3
+        assert session.get(Group, 2).super_id is None   # dangling -> NULL
+        assert session.get(Group, 3).super_id == 1       # valid kept
+
+
+def test_sync_all_includes_phase3_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "MASHI": [{"ID": 1, "DATE": "2026-01-05", "EMPLOYEEID": 10, "SHIFTID": 1}],
+            "SPSHI": [{"ID": 1, "DATE": "2026-01-06", "EMPLOYEEID": 10}],
+            "ABSEN": [{"ID": 1, "DATE": "2026-01-07", "EMPLOYEEID": 10, "LEAVETYPID": 5}],
+        },
+    )
+    stats = sync.sync_all(engine, "/x")
+    assert stats["shift_assignments"] == 1
+    assert stats["special_shifts"] == 1
+    assert stats["absences"] == 1


### PR DESCRIPTION
Implements **from-app issue #5** — ORM Phase 3 (the time-based roster) plus a sync robustness fix reported from Phase-2 consumption.

## What

- **Models** `ShiftAssignment` (`5MASHI.DBF` → `schedule_entries`), `SpecialShift` (`5SPSHI.DBF`), `Absence` (`5ABSEN.DBF`) — importable from `sp5lib.orm`, each with `to_dict()` mirroring the DBF keys (`DATE`/`EMPLOYEEID`/`SHIFTID`/`WORKPLACID`/`LEAVETYPID`/`TYPE`/…). `init_db()` creates the tables.
- **Repositories** `ShiftAssignmentRepository`, `SpecialShiftRepository`, `AbsenceRepository` with `list(date_from=None, date_to=None, employee_id=None)` (ISO date-window + per-employee) and `get(id)`.
- **Sync** `sync_shift_assignments` / `sync_special_shifts` / `sync_absences`, wired into `sync_all()`. Blank/invalid `DATE` → skipped + logged. employee/shift/leave-type references are **plain indexed integers, no DB-level FK** → dirty legacy data syncs (FK-tolerant, per acceptance criterion 2).

## Fix: `sync_groups` dangling `super_id`

Regression reported from v1.2.0: `sync_all` aborted with `FOREIGN KEY constraint failed` when `5GROUP.DBF` had a `super_id` pointing at a non-existent group (fixture: group 2 → super_id 61, missing). `super_id` is now resolved in a **second pass** against the full set of known group IDs — dangling references are set to `NULL` and logged, and DBF row ordering no longer matters. `company_id` is not populated by sync, so it cannot dangle.

## Design note (single source of truth)

`ScheduleEntry`/`SpecialShift`/`Absence` already existed in `models_pg.py` (same `Base.metadata`, imported by `pg_database`). As in Phase 2, the three are now defined **canonically in `models.py`** and **re-exported** from `models_pg.py`. The MASHI model is renamed to the spec's `ShiftAssignment`, with **`ScheduleEntry` kept as a backward-compatible alias** — `from sp5lib.orm.models_pg import ScheduleEntry, SpecialShift, Absence` (used by `pg_database`, incl. `ScheduleEntry(...)` / `Absence(...)` construction) keeps working unchanged.

## Acceptance criteria

- [x] Models `ShiftAssignment`/`SpecialShift`/`Absence` in `models.py`, exported via `__init__`, `to_dict()` mirrors DBF keys
- [x] FK-tolerant (plain Integer + Index, no enforced FK)
- [x] Repositories with `list(date_from, date_to, employee_id)`
- [x] `sync_*` + `sync_all`, robust DATE parsing (invalid skipped/logged)
- [x] Tests (in-memory SQLite); SQLite + Postgres schema kept in sync (single source)
- [x] `sync_groups` dangling `super_id` fixed
- [x] Version → **1.3.0** for the PyPI release (tag pushed after merge)

Local: `ruff` clean, **38 tests pass**, `python -m build` + `twine check --strict` clean.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)