### PR TITLE
feat(orm): Phase 4 — Holiday/Period models + fix sync_group_assignments UNIQUE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-05-27
+
+ORM Phase 4 — reference tables (holidays, accounting periods) plus a sync
+robustness fix that lets `sync_all()` run to completion on real data.
+
+### Added
+
+- **`Holiday`** (`holidays`, from `5HOLID.DBF`) and **`Period`** (`periods`,
+  from `5PERIO.DBF`) ORM models, importable from `sp5lib.orm`, with `to_dict()`
+  mirroring the real DBF keys. `init_db()` creates the tables.
+- **`HolidayRepository`** with `list(year=None)` (a given year plus recurring
+  `interval == 1` holidays) and `get(id)`.
+- **`PeriodRepository`** with `list(date_from=None, date_to=None,
+  group_id=None)` and `get(id)`.
+- DBF → ORM upsert `sync.sync_holidays` and `sync.sync_periods`, wired into
+  `sync.sync_all()`.
+
+### Fixed
+
+- `sync.sync_group_assignments` no longer aborts `sync_all` with
+  `UNIQUE constraint failed: group_assignments.id`. The `ID` column in
+  `5GRASG.DBF` is a per-group running index, not a global key, so it is no
+  longer used as the primary key (the autoincrement `id` is). Assignments are
+  de-duplicated on `(employee_id, group_id)`, and rows referencing a
+  non-existent employee or group are skipped and logged. `sync_all()` now
+  completes over the full set of tables.
+
+### Changed
+
+- `Holiday` is now defined canonically in `sp5lib.orm.models` and re-exported
+  from `sp5lib.orm.models_pg` (used by `pg_database`); `Period` is likewise
+  available from both. No behaviour change for existing imports.
+
+### Notes
+
+- `Period` maps the DBF `DESCRIPT` field (the period label) — the request
+  referred to it as `NAME`, but the actual `5PERIO.DBF` field is `DESCRIPT`,
+  which `to_dict()` mirrors (alongside `GROUPID` / `START` / `END` / `COLOR`).
+
 ## [1.3.0] - 2026-05-27
 
 ORM Phase 3 — the time-based roster. Adds the schedule-entry tables to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
-version = "1.3.0"
+version = "1.4.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/sp5lib/orm/README.md
+++ b/sp5lib/orm/README.md
@@ -86,9 +86,9 @@ This initial implementation covers:
 1. ✅ **Phase 1**: ORM models + repositories for Employees & Groups
 2. ✅ **Phase 2**: ORM models + repositories + DBF sync for Shifts, LeaveTypes, Workplaces
 3. ✅ **Phase 3**: ORM models + repositories + DBF sync for Schedule entries (MASHI → ShiftAssignment, SPSHI → SpecialShift, ABSEN → Absence)
-4. **Phase 4**: Wire ORM repositories into FastAPI routers (dual-read)
-5. **Phase 5**: Switch write path to ORM, keep DBF sync for legacy
-6. **Phase 6**: Drop DBF dependency, run on PostgreSQL
+4. ✅ **Phase 4**: ORM models + repositories + DBF sync for reference tables (5HOLID → Holiday, 5PERIO → Period); `sync_all()` now runs over all tables
+5. **Next**: Wire ORM repositories into FastAPI routers (dual-read) — app-side
+6. **Later**: Switch write path to ORM, keep DBF sync for legacy; then drop the DBF dependency and run on PostgreSQL
 
 ## Usage Example
 

--- a/sp5lib/orm/__init__.py
+++ b/sp5lib/orm/__init__.py
@@ -24,7 +24,9 @@ from .models import (
     Employee,
     Group,
     GroupAssignment,
+    Holiday,
     LeaveType,
+    Period,
     Shift,
     ShiftAssignment,
     SpecialShift,
@@ -34,7 +36,9 @@ from .repository import (
     AbsenceRepository,
     EmployeeRepository,
     GroupRepository,
+    HolidayRepository,
     LeaveTypeRepository,
+    PeriodRepository,
     ShiftAssignmentRepository,
     ShiftRepository,
     SpecialShiftRepository,
@@ -63,6 +67,9 @@ __all__ = [
     "ScheduleEntry",
     "SpecialShift",
     "Absence",
+    # Reference (Phase 4) models
+    "Holiday",
+    "Period",
     # Repositories
     "EmployeeRepository",
     "GroupRepository",
@@ -72,4 +79,6 @@ __all__ = [
     "ShiftAssignmentRepository",
     "SpecialShiftRepository",
     "AbsenceRepository",
+    "HolidayRepository",
+    "PeriodRepository",
 ]

--- a/sp5lib/orm/models.py
+++ b/sp5lib/orm/models.py
@@ -507,3 +507,65 @@ class Absence(Base):
             "START": self.start,
             "END": self.end,
         }
+
+
+# ── Phase 4: reference tables (holidays, accounting periods) ─────────────────
+# Holiday is defined canonically here and re-exported from models_pg.py. Period
+# is new in Phase 4. group_id is a plain Integer (no DB-level FK), consistent
+# with the FK-tolerant approach used by the schedule tables.
+
+
+class Holiday(Base):
+    """Public holiday (Feiertag) — maps to 5HOLID.DBF."""
+
+    __tablename__ = "holidays"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    interval: Mapped[int] = mapped_column(Integer, default=0, doc="1 = recurring every year")
+
+    __table_args__ = (Index("idx_holiday_date", "date"),)
+
+    def __repr__(self) -> str:
+        return f"<Holiday(id={self.id}, date='{self.date}', name='{self.name}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "DATE": self.date,
+            "NAME": self.name,
+            "INTERVAL": self.interval,
+        }
+
+
+class Period(Base):
+    """Accounting / planning period (Periode) — maps to 5PERIO.DBF.
+
+    The DBF stores the label in ``DESCRIPT`` (not ``NAME``); ``to_dict()``
+    mirrors the real DBF keys.
+    """
+
+    __tablename__ = "periods"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(Integer, default=0, doc="Owning group (no FK)")
+    start: Mapped[str | None] = mapped_column(String(10), default="", doc="ISO start date")
+    end: Mapped[str | None] = mapped_column(String(10), default="", doc="ISO end date")
+    color: Mapped[int] = mapped_column(Integer, default=16777215)
+    description: Mapped[str | None] = mapped_column(String(200), default="")
+
+    __table_args__ = (Index("idx_period_group", "group_id"),)
+
+    def __repr__(self) -> str:
+        return f"<Period(id={self.id}, start='{self.start}', end='{self.end}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "GROUPID": self.group_id,
+            "START": self.start or "",
+            "END": self.end or "",
+            "COLOR": self.color,
+            "DESCRIPT": self.description or "",
+        }

--- a/sp5lib/orm/models_pg.py
+++ b/sp5lib/orm/models_pg.py
@@ -24,7 +24,9 @@ from .base import Base
 # working unchanged. ScheduleEntry is the legacy name for ShiftAssignment.
 from .models import (  # noqa: F401,E402
     Absence,
+    Holiday,
     LeaveType,
+    Period,
     Shift,
     ShiftAssignment,
     SpecialShift,
@@ -35,17 +37,6 @@ from .models import (  # noqa: F401,E402
 # called ScheduleEntry. It is now ShiftAssignment (same table "schedule_entries",
 # same columns); keep the old name importable for existing consumers.
 ScheduleEntry = ShiftAssignment
-
-
-class Holiday(Base):
-    __tablename__ = "holidays"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    name: Mapped[str] = mapped_column(String(200), nullable=False)
-    interval: Mapped[int] = mapped_column(Integer, default=0)
-
-    def to_dict(self) -> dict:
-        return {"ID": self.id, "DATE": self.date, "NAME": self.name, "INTERVAL": self.interval}
 
 
 class User(Base):

--- a/sp5lib/orm/repository.py
+++ b/sp5lib/orm/repository.py
@@ -18,7 +18,9 @@ from .models import (
     Employee,
     Group,
     GroupAssignment,
+    Holiday,
     LeaveType,
+    Period,
     Shift,
     ShiftAssignment,
     SpecialShift,
@@ -331,3 +333,60 @@ class AbsenceRepository:
     def get(self, entry_id: int) -> Absence | None:
         """Return a single absence by ID, or None."""
         return self.session.get(Absence, entry_id)
+
+
+class HolidayRepository:
+    """Data access for public holidays (5HOLID.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(self, year: int | None = None) -> list[Holiday]:
+        """Return holidays ordered by date.
+
+        With ``year`` set, returns holidays in that calendar year plus all
+        recurring (``interval == 1``) holidays, which apply every year.
+        """
+        stmt = select(Holiday).order_by(Holiday.date)
+        if year is not None:
+            prefix = f"{year:04d}-"
+            stmt = stmt.where(
+                (Holiday.date.startswith(prefix)) | (Holiday.interval == 1)
+            )
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, holiday_id: int) -> Holiday | None:
+        """Return a single holiday by ID, or None."""
+        return self.session.get(Holiday, holiday_id)
+
+
+class PeriodRepository:
+    """Data access for accounting / planning periods (5PERIO.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        group_id: int | None = None,
+    ) -> list[Period]:
+        """Return periods ordered by start date, optionally filtered.
+
+        ``date_from`` / ``date_to`` filter on the period start date (ISO
+        strings); ``group_id`` restricts to one group.
+        """
+        stmt = select(Period)
+        if date_from is not None:
+            stmt = stmt.where(Period.start >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(Period.start <= date_to)
+        if group_id is not None:
+            stmt = stmt.where(Period.group_id == group_id)
+        stmt = stmt.order_by(Period.start, Period.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, period_id: int) -> Period | None:
+        """Return a single period by ID, or None."""
+        return self.session.get(Period, period_id)

--- a/sp5lib/orm/sync.py
+++ b/sp5lib/orm/sync.py
@@ -26,7 +26,9 @@ from .models import (
     Employee,
     Group,
     GroupAssignment,
+    Holiday,
     LeaveType,
+    Period,
     Shift,
     ShiftAssignment,
     SpecialShift,
@@ -171,25 +173,50 @@ def sync_groups(session: Session, daten_path: str) -> int:
 
 
 def sync_group_assignments(session: Session, daten_path: str) -> int:
-    """Sync group assignments from 5GRASG.DBF."""
+    """Sync group assignments from 5GRASG.DBF (full delete + re-insert).
+
+    The ``ID`` column in 5GRASG.DBF is **not** a globally unique key — it is a
+    per-group running index, so the same value repeats across different
+    employee/group pairs. We therefore do NOT use it as the primary key (the
+    autoincrement ``GroupAssignment.id`` does that); the logical identity is the
+    ``UNIQUE(employee_id, group_id)`` pair. Duplicate pairs are de-duplicated,
+    and rows whose employee or group does not exist are skipped (those columns
+    are real FKs, so a dangling reference would otherwise abort the sync).
+    """
     rows = _read_dbf(daten_path, "GRASG")
 
-    # Clear existing assignments and re-insert (simple full-sync approach)
+    # Clear existing assignments and re-insert (simple full-sync approach).
     session.query(GroupAssignment).delete()
     session.flush()
 
+    valid_emp_ids = set(session.scalars(select(Employee.id)).all())
+    valid_group_ids = set(session.scalars(select(Group.id)).all())
+
     count = 0
+    seen: set[tuple[int, int]] = set()
+    skipped_dangling = 0
     for r in rows:
-        ga_id = r.get("ID")
         emp_id = r.get("EMPLOYEEID")
         group_id = r.get("GROUPID")
-        if not ga_id or not emp_id or not group_id:
+        if not emp_id or not group_id:
+            continue
+        pair = (emp_id, group_id)
+        if pair in seen:
+            continue  # duplicate (employee, group) — keep a single assignment
+        if emp_id not in valid_emp_ids or group_id not in valid_group_ids:
+            skipped_dangling += 1
             continue
 
-        ga = GroupAssignment(id=ga_id, employee_id=emp_id, group_id=group_id)
-        session.add(ga)
+        seen.add(pair)
+        # Let the autoincrement PK assign the id; the DBF ID is not unique.
+        session.add(GroupAssignment(employee_id=emp_id, group_id=group_id))
         count += 1
 
+    if skipped_dangling:
+        _log.warning(
+            "sync_group_assignments: skipped %d row(s) with dangling employee/group reference",
+            skipped_dangling,
+        )
     session.flush()
     return count
 
@@ -400,6 +427,67 @@ def sync_absences(session: Session, daten_path: str) -> int:
     return count
 
 
+def sync_holidays(session: Session, daten_path: str) -> int:
+    """Sync public holidays from 5HOLID.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "HOLID")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        hol_id = r.get("ID")
+        if not hol_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        hol = session.get(Holiday, hol_id)
+        if hol is None:
+            hol = Holiday(id=hol_id)
+            session.add(hol)
+
+        hol.date = date
+        hol.name = str(r.get("NAME") or "").strip()
+        hol.interval = r.get("INTERVAL", 0) or 0
+        count += 1
+
+    if skipped:
+        _log.warning("sync_holidays: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_periods(session: Session, daten_path: str) -> int:
+    """Sync accounting/planning periods from 5PERIO.DBF.
+
+    The DBF stores the label in DESCRIPT and the owning group in GROUPID
+    (a plain integer, no FK). START/END are date strings as parsed by read_dbf.
+    """
+    rows = _read_dbf(daten_path, "PERIO")
+    count = 0
+
+    for r in rows:
+        per_id = r.get("ID")
+        if not per_id:
+            continue
+
+        per = session.get(Period, per_id)
+        if per is None:
+            per = Period(id=per_id)
+            session.add(per)
+
+        per.group_id = r.get("GROUPID", 0) or 0
+        per.start = str(r.get("START") or "").strip()
+        per.end = str(r.get("END") or "").strip()
+        per.color = r.get("COLOR", 16777215) or 16777215
+        per.description = str(r.get("DESCRIPT") or "").strip()
+        count += 1
+
+    session.flush()
+    return count
+
+
 def sync_all(engine, daten_path: str) -> dict[str, int]:
     """Sync all supported tables from DBF into the ORM database.
 
@@ -417,6 +505,8 @@ def sync_all(engine, daten_path: str) -> dict[str, int]:
         stats["shift_assignments"] = sync_shift_assignments(session, daten_path)
         stats["special_shifts"] = sync_special_shifts(session, daten_path)
         stats["absences"] = sync_absences(session, daten_path)
+        stats["holidays"] = sync_holidays(session, daten_path)
+        stats["periods"] = sync_periods(session, daten_path)
         session.commit()
         _log.info("ORM sync complete: %s", stats)
         return stats

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -15,9 +15,15 @@ import pytest
 from sp5lib.orm import (
     Absence,
     AbsenceRepository,
+    Employee,
     Group,
+    GroupAssignment,
+    Holiday,
+    HolidayRepository,
     LeaveType,
     LeaveTypeRepository,
+    Period,
+    PeriodRepository,
     ScheduleEntry,
     Shift,
     ShiftAssignment,
@@ -399,3 +405,150 @@ def test_sync_all_includes_phase3_tables(engine, monkeypatch):
     assert stats["shift_assignments"] == 1
     assert stats["special_shifts"] == 1
     assert stats["absences"] == 1
+
+
+# ─── Phase 4: holiday / period models + repositories ────────────────────────────
+
+
+def test_init_db_creates_phase4_tables(engine):
+    from sqlalchemy import inspect
+
+    tables = set(inspect(engine).get_table_names())
+    assert {"holidays", "periods"} <= tables
+
+
+def test_holiday_reexported_from_models_pg():
+    from sp5lib.orm import models, models_pg
+
+    assert models.Holiday is models_pg.Holiday
+    assert models.Period is models_pg.Period
+
+
+def test_holiday_repository_year_filter(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                Holiday(id=1, date="2025-12-25", name="Weihnachten 2025"),
+                Holiday(id=2, date="2026-01-01", name="Neujahr 2026"),
+                Holiday(id=3, date="2026-05-01", name="Tag der Arbeit", interval=1),
+            ]
+        )
+        session.flush()
+        repo = HolidayRepository(session)
+        assert [h.id for h in repo.list()] == [1, 2, 3]
+        # year 2026: the two 2026 entries, plus the recurring one (id 3 already 2026)
+        ids_2026 = {h.id for h in repo.list(year=2026)}
+        assert ids_2026 == {2, 3}
+        # recurring holiday shows up even when querying a different year
+        assert 3 in {h.id for h in repo.list(year=2030)}
+        assert repo.get(1).name == "Weihnachten 2025"
+
+
+def test_period_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                Period(id=1, group_id=1, start="2026-01-01", end="2026-03-31", description="Q1"),
+                Period(id=2, group_id=1, start="2026-04-01", end="2026-06-30", description="Q2"),
+                Period(id=3, group_id=2, start="2026-01-01", end="2026-12-31", description="Jahr"),
+            ]
+        )
+        session.flush()
+        repo = PeriodRepository(session)
+        assert [p.id for p in repo.list()] == [1, 3, 2]  # ordered by start, then id
+        assert [p.id for p in repo.list(group_id=1)] == [1, 2]
+        assert [p.id for p in repo.list(date_from="2026-04-01")] == [2]
+        assert repo.get(3).description == "Jahr"
+
+
+def test_holiday_and_period_to_dict_mirror_dbf_keys():
+    assert Holiday(id=1, date="2026-01-01", name="Neujahr", interval=1).to_dict() == {
+        "ID": 1, "DATE": "2026-01-01", "NAME": "Neujahr", "INTERVAL": 1,
+    }
+    d = Period(id=1, group_id=2, start="2026-01-01", end="2026-12-31",
+               color=255, description="Jahr").to_dict()
+    assert d == {
+        "ID": 1, "GROUPID": 2, "START": "2026-01-01", "END": "2026-12-31",
+        "COLOR": 255, "DESCRIPT": "Jahr",
+    }
+
+
+# ─── Phase 4 sync ───────────────────────────────────────────────────────────────
+
+
+def test_sync_holidays_and_periods(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "HOLID": [
+                {"ID": 1, "DATE": "2026-01-01", "NAME": "Neujahr", "INTERVAL": 1},
+                {"ID": 2, "DATE": "", "NAME": "kaputt"},  # invalid date -> skipped
+            ],
+            "PERIO": [
+                {"ID": 1, "GROUPID": 1, "START": "2026-01-01", "END": "2026-03-31",
+                 "COLOR": 255, "DESCRIPT": "Q1"},
+            ],
+        },
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_holidays(session, "/x") == 1
+        assert sync.sync_periods(session, "/x") == 1
+        assert HolidayRepository(session).get(1).interval == 1
+        # DESCRIPT (not NAME) carries the period label
+        assert PeriodRepository(session).get(1).description == "Q1"
+
+
+# ─── Teil A: sync_group_assignments UNIQUE / dedup / dangling fix ────────────────
+
+
+def test_sync_group_assignments_non_unique_dbf_ids(engine, monkeypatch):
+    # Regression for the v1.3.0 defect: 5GRASG.DBF IDs are not unique (per-group
+    # running index). The sync must not use them as PK (no UNIQUE/IntegrityError),
+    # must de-duplicate (employee, group) pairs, and must skip dangling refs.
+    from sqlalchemy import select
+
+    from sp5lib.orm import sync
+
+    with session_scope(engine) as session:
+        session.add_all([Employee(id=i, name=f"E{i}") for i in (40, 41, 42, 43, 44)])
+        session.add_all([Group(id=i, name=f"G{i}") for i in (51, 54, 2, 55)])
+        session.flush()
+
+    _patch_dbf(
+        monkeypatch,
+        {"GRASG": [
+            {"ID": 1, "EMPLOYEEID": 40, "GROUPID": 51},
+            {"ID": 2, "EMPLOYEEID": 41, "GROUPID": 54},
+            {"ID": 2, "EMPLOYEEID": 42, "GROUPID": 54},   # repeated DBF ID, distinct pair
+            {"ID": 1, "EMPLOYEEID": 44, "GROUPID": 2},    # repeated DBF ID, distinct pair
+            {"ID": 3, "EMPLOYEEID": 43, "GROUPID": 55},
+            {"ID": 9, "EMPLOYEEID": 40, "GROUPID": 51},   # duplicate pair -> deduped
+            {"ID": 10, "EMPLOYEEID": 999, "GROUPID": 51},  # dangling employee -> skipped
+        ]},
+    )
+    with session_scope(engine) as session:
+        # must not raise IntegrityError; returns the count of unique valid pairs
+        assert sync.sync_group_assignments(session, "/x") == 5
+        rows = list(session.scalars(select(GroupAssignment)).all())
+        pairs = {(r.employee_id, r.group_id) for r in rows}
+        assert pairs == {(40, 51), (41, 54), (42, 54), (44, 2), (43, 55)}
+        # PKs are autoincrement (not the non-unique DBF IDs)
+        assert len({r.id for r in rows}) == 5
+
+
+def test_sync_all_includes_phase4_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "HOLID": [{"ID": 1, "DATE": "2026-01-01", "NAME": "Neujahr"}],
+            "PERIO": [{"ID": 1, "GROUPID": 1, "START": "2026-01-01", "END": "2026-12-31",
+                       "DESCRIPT": "Jahr"}],
+        },
+    )
+    stats = sync.sync_all(engine, "/x")
+    assert stats["holidays"] == 1
+    assert stats["periods"] == 1


### PR DESCRIPTION
Implements **from-app issue #7**.

## Part A (priority) — fix `sync_group_assignments` UNIQUE

`sync_all` (v1.3.0) aborted with `UNIQUE constraint failed: group_assignments.id`. The `ID` column in `5GRASG.DBF` is a **per-group running index**, not a global key — the values 1/2/3 repeat across different employee/group pairs — but the sync set `GroupAssignment(id=ga_id, …)`.

Fix:
- The DBF `ID` is **no longer used as the PK** — the existing autoincrement `id` assigns it.
- Assignments are **de-duplicated on `(employee_id, group_id)`** (the model's `UNIQUE` index).
- Rows whose `employee_id`/`group_id` don't exist are **skipped + logged** (those are real FKs with CASCADE, so a dangling ref would otherwise abort the sync).

→ `sync_all()` now runs over the full set of tables, so the app's ORM-mirror can switch from per-table sync to `sync_all`.

## Part B — Phase 4 reference tables

- **`Holiday`** (`5HOLID.DBF` → `holidays`) and **`Period`** (`5PERIO.DBF` → `periods`) models, importable from `sp5lib.orm`, `to_dict()` mirroring the real DBF keys. `init_db()` creates the tables.
- **`HolidayRepository`** `list(year=None)` (given year + recurring `interval==1`) + `get(id)`.
- **`PeriodRepository`** `list(date_from=None, date_to=None, group_id=None)` + `get(id)`.
- `sync_holidays` / `sync_periods`, wired into `sync_all()`.

## Notes / decisions

- **`Period` field naming:** the issue listed `START`/`END`/`NAME`, but the real `5PERIO.DBF` label field is **`DESCRIPT`** (confirmed against `database.get_periods`), alongside `GROUPID`/`COLOR`. `to_dict()` mirrors the actual DBF keys (`ID`/`GROUPID`/`START`/`END`/`COLOR`/`DESCRIPT`).
- `Holiday` already existed in `models_pg.py` (imported by `pg_database`); as in Phases 2–3 it's now canonical in `models.py` and **re-exported** from `models_pg.py`. `Period` is available from both. No breakage for existing imports.
- Phase-4 references (`group_id`, employee/shift/leave-type on schedule tables) stay FK-tolerant (plain indexed integers).

## Acceptance criteria

- [x] `sync_group_assignments` robust against non-unique DBF IDs; `sync_all` completes
- [x] `Holiday` + `Period` models, exported via `__init__`, `to_dict()` mirrors DBF keys, FK-tolerant
- [x] `HolidayRepository.list(year)`, `PeriodRepository` date-range, both `get(id)`
- [x] `sync_holidays`/`sync_periods` in `sync_all`
- [x] Tests (in-memory SQLite); SQLite + Postgres schema synchronous (single source)
- [x] Version → **1.4.0** for PyPI (tag after merge)

Local: `ruff` clean, **46 tests pass**, `build` + `twine check --strict` clean.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)