### PR TITLE
feat(orm): Phase 5 — account bookings, overtime & leave entitlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-05-27
+
+ORM Phase 5 — account bookings, overtime and leave entitlements (the data
+behind the time-account / overtime / leave-balance features). Additive and
+backward compatible.
+
+### Added
+
+- **`AccountBooking`** (`bookings_pg`, from `5BOOK.DBF`), **`OvertimeEntry`**
+  (`overtime_records`, `5OVER.DBF`) and **`LeaveEntitlement`**
+  (`leave_entitlements`, `5LEAEN.DBF`) ORM models, importable from
+  `sp5lib.orm`, with `to_dict()` mirroring the real DBF keys. `init_db()`
+  creates the tables.
+- **`AccountBookingRepository`** and **`OvertimeEntryRepository`** with
+  `list(date_from=None, date_to=None, employee_id=None)` + `get(id)`;
+  **`LeaveEntitlementRepository`** with `list(year=None, employee_id=None)` +
+  `get(id)`.
+- DBF → ORM upsert `sync.sync_book`, `sync.sync_overtime`,
+  `sync.sync_leave_entitlements`, wired into `sync.sync_all()`. `BOOK`/`OVER`
+  rows with a blank/invalid `DATE` are skipped and logged. `sync_all()` now
+  covers 14 tables.
+
+### Changed
+
+- `AccountBooking` / `OvertimeEntry` / `LeaveEntitlement` are defined
+  canonically in `sp5lib.orm.models` and re-exported from
+  `sp5lib.orm.models_pg`. The previous names **`Booking`** (→ `AccountBooking`)
+  and **`OvertimeRecord`** (→ `OvertimeEntry`) remain importable as aliases
+  (same tables `bookings_pg` / `overtime_records`), so existing imports keep
+  working.
+
+### Notes
+
+- `LeaveEntitlement` maps the DBF fields `ENTITLEMNT` → `entitlement`,
+  `REST` → `carry_forward`, `INDAYS` → `in_days`; `to_dict()` mirrors the DBF
+  spellings (`ENTITLEMNT` / `REST` / `INDAYS`).
+
 ## [1.4.0] - 2026-05-27
 
 ORM Phase 4 — reference tables (holidays, accounting periods) plus a sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
-version = "1.4.0"
+version = "1.5.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/sp5lib/orm/README.md
+++ b/sp5lib/orm/README.md
@@ -87,8 +87,9 @@ This initial implementation covers:
 2. ✅ **Phase 2**: ORM models + repositories + DBF sync for Shifts, LeaveTypes, Workplaces
 3. ✅ **Phase 3**: ORM models + repositories + DBF sync for Schedule entries (MASHI → ShiftAssignment, SPSHI → SpecialShift, ABSEN → Absence)
 4. ✅ **Phase 4**: ORM models + repositories + DBF sync for reference tables (5HOLID → Holiday, 5PERIO → Period); `sync_all()` now runs over all tables
-5. **Next**: Wire ORM repositories into FastAPI routers (dual-read) — app-side
-6. **Later**: Switch write path to ORM, keep DBF sync for legacy; then drop the DBF dependency and run on PostgreSQL
+5. ✅ **Phase 5**: ORM models + repositories + DBF sync for account/overtime/entitlements (5BOOK → AccountBooking, 5OVER → OvertimeEntry, 5LEAEN → LeaveEntitlement); `sync_all()` covers 14 tables
+6. **Next**: Wire ORM repositories into FastAPI routers (dual-read) — app-side
+7. **Later**: Switch write path to ORM, keep DBF sync for legacy; then drop the DBF dependency and run on PostgreSQL
 
 ## Usage Example
 

--- a/sp5lib/orm/__init__.py
+++ b/sp5lib/orm/__init__.py
@@ -20,12 +20,15 @@ Usage:
 from .base import Base, get_engine, get_session, init_db
 from .models import (
     Absence,
+    AccountBooking,
     Company,
     Employee,
     Group,
     GroupAssignment,
     Holiday,
+    LeaveEntitlement,
     LeaveType,
+    OvertimeEntry,
     Period,
     Shift,
     ShiftAssignment,
@@ -34,10 +37,13 @@ from .models import (
 )
 from .repository import (
     AbsenceRepository,
+    AccountBookingRepository,
     EmployeeRepository,
     GroupRepository,
     HolidayRepository,
+    LeaveEntitlementRepository,
     LeaveTypeRepository,
+    OvertimeEntryRepository,
     PeriodRepository,
     ShiftAssignmentRepository,
     ShiftRepository,
@@ -45,8 +51,10 @@ from .repository import (
     WorkplaceRepository,
 )
 
-# Legacy alias for the MASHI master-schedule model (now ShiftAssignment).
+# Legacy aliases for models renamed when they moved to models.py (same tables).
 ScheduleEntry = ShiftAssignment
+Booking = AccountBooking
+OvertimeRecord = OvertimeEntry
 
 __all__ = [
     # Engine / session / schema
@@ -70,6 +78,12 @@ __all__ = [
     # Reference (Phase 4) models
     "Holiday",
     "Period",
+    # Account / overtime / entitlement (Phase 5) models
+    "AccountBooking",
+    "Booking",
+    "OvertimeEntry",
+    "OvertimeRecord",
+    "LeaveEntitlement",
     # Repositories
     "EmployeeRepository",
     "GroupRepository",
@@ -81,4 +95,7 @@ __all__ = [
     "AbsenceRepository",
     "HolidayRepository",
     "PeriodRepository",
+    "AccountBookingRepository",
+    "OvertimeEntryRepository",
+    "LeaveEntitlementRepository",
 ]

--- a/sp5lib/orm/models.py
+++ b/sp5lib/orm/models.py
@@ -569,3 +569,101 @@ class Period(Base):
             "COLOR": self.color,
             "DESCRIPT": self.description or "",
         }
+
+
+# ── Phase 5: account bookings, overtime, leave entitlements ──────────────────
+# Defined canonically here and re-exported from models_pg.py, where the former
+# names Booking / OvertimeRecord remain available as aliases. References
+# (employee_id / leave_type_id) are plain indexed integers without DB-level FK
+# constraints, consistent with the other roster tables.
+
+
+class AccountBooking(Base):
+    """Manual account / time booking — maps to 5BOOK.DBF."""
+
+    __tablename__ = "bookings_pg"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    booking_type: Mapped[int] = mapped_column(Integer, default=0, doc="DBF TYPE")
+    value: Mapped[float] = mapped_column(Float, default=0.0, doc="DBF VALUE")
+    note: Mapped[str | None] = mapped_column(Text, default="", doc="DBF NOTE")
+
+    __table_args__ = (
+        Index("idx_book_emp_date", "employee_id", "date"),
+        Index("idx_book_date", "date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AccountBooking(id={self.id}, emp={self.employee_id}, date='{self.date}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "EMPLOYEEID": self.employee_id,
+            "DATE": self.date,
+            "TYPE": self.booking_type,
+            "VALUE": self.value,
+            "NOTE": self.note or "",
+        }
+
+
+class OvertimeEntry(Base):
+    """Manual overtime adjustment — maps to 5OVER.DBF."""
+
+    __tablename__ = "overtime_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    hours: Mapped[float] = mapped_column(Float, default=0.0)
+
+    __table_args__ = (
+        Index("idx_overtime_emp_date", "employee_id", "date"),
+        Index("idx_overtime_date", "date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<OvertimeEntry(id={self.id}, emp={self.employee_id}, hours={self.hours})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "EMPLOYEEID": self.employee_id,
+            "DATE": self.date,
+            "HOURS": self.hours,
+        }
+
+
+class LeaveEntitlement(Base):
+    """Annual leave entitlement per employee — maps to 5LEAEN.DBF.
+
+    DBF fields: ENTITLEMNT (entitlement), REST (carry_forward), INDAYS (in_days).
+    """
+
+    __tablename__ = "leave_entitlements"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    leave_type_id: Mapped[int] = mapped_column(Integer, default=0)
+    entitlement: Mapped[float] = mapped_column(Float, default=0.0, doc="DBF ENTITLEMNT")
+    carry_forward: Mapped[float] = mapped_column(Float, default=0.0, doc="DBF REST")
+    in_days: Mapped[bool] = mapped_column(Boolean, default=True, doc="DBF INDAYS")
+
+    __table_args__ = (Index("idx_leaen_emp_year", "employee_id", "year"),)
+
+    def __repr__(self) -> str:
+        return f"<LeaveEntitlement(id={self.id}, emp={self.employee_id}, year={self.year})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "EMPLOYEEID": self.employee_id,
+            "YEAR": self.year,
+            "LEAVETYPID": self.leave_type_id,
+            "ENTITLEMNT": self.entitlement,
+            "REST": self.carry_forward,
+            "INDAYS": self.in_days,
+        }

--- a/sp5lib/orm/models_pg.py
+++ b/sp5lib/orm/models_pg.py
@@ -8,7 +8,6 @@ models already defined in models.py.
 
 from sqlalchemy import (
     Boolean,
-    Float,
     Integer,
     LargeBinary,
     String,
@@ -24,8 +23,11 @@ from .base import Base
 # working unchanged. ScheduleEntry is the legacy name for ShiftAssignment.
 from .models import (  # noqa: F401,E402
     Absence,
+    AccountBooking,
     Holiday,
+    LeaveEntitlement,
     LeaveType,
+    OvertimeEntry,
     Period,
     Shift,
     ShiftAssignment,
@@ -33,10 +35,14 @@ from .models import (  # noqa: F401,E402
     Workplace,
 )
 
-# Backward-compatible alias: the MASHI master-schedule model was previously
-# called ScheduleEntry. It is now ShiftAssignment (same table "schedule_entries",
-# same columns); keep the old name importable for existing consumers.
+# Backward-compatible aliases for models that were renamed when they moved to
+# models.py (same tables, same columns) — keep the old names importable:
+#   ScheduleEntry  -> ShiftAssignment (5MASHI, "schedule_entries")
+#   Booking        -> AccountBooking  (5BOOK,  "bookings_pg")
+#   OvertimeRecord -> OvertimeEntry   (5OVER,  "overtime_records")
 ScheduleEntry = ShiftAssignment
+Booking = AccountBooking
+OvertimeRecord = OvertimeEntry
 
 
 class User(Base):
@@ -110,35 +116,6 @@ class Note(Base):
     text1: Mapped[str | None] = mapped_column(Text, default="")
     text2: Mapped[str | None] = mapped_column(Text, default="")
     category: Mapped[str | None] = mapped_column(String(20), default="")
-
-
-class Booking(Base):
-    __tablename__ = "bookings_pg"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    booking_type: Mapped[int] = mapped_column(Integer, default=0)
-    value: Mapped[float] = mapped_column(Float, default=0.0)
-    note: Mapped[str | None] = mapped_column(Text, default="")
-
-
-class OvertimeRecord(Base):
-    __tablename__ = "overtime_records"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    date: Mapped[str] = mapped_column(String(10), nullable=False)
-    hours: Mapped[float] = mapped_column(Float, default=0.0)
-
-
-class LeaveEntitlement(Base):
-    __tablename__ = "leave_entitlements"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    year: Mapped[int] = mapped_column(Integer, nullable=False)
-    leave_type_id: Mapped[int] = mapped_column(Integer, default=0)
-    entitlement: Mapped[float] = mapped_column(Float, default=0.0)
-    carry_forward: Mapped[float] = mapped_column(Float, default=0.0)
-    in_days: Mapped[bool] = mapped_column(Boolean, default=True)
 
 
 class Restriction(Base):

--- a/sp5lib/orm/repository.py
+++ b/sp5lib/orm/repository.py
@@ -15,11 +15,14 @@ from sqlalchemy.orm import Session
 
 from .models import (
     Absence,
+    AccountBooking,
     Employee,
     Group,
     GroupAssignment,
     Holiday,
+    LeaveEntitlement,
     LeaveType,
+    OvertimeEntry,
     Period,
     Shift,
     ShiftAssignment,
@@ -390,3 +393,84 @@ class PeriodRepository:
     def get(self, period_id: int) -> Period | None:
         """Return a single period by ID, or None."""
         return self.session.get(Period, period_id)
+
+
+class AccountBookingRepository:
+    """Data access for manual account / time bookings (5BOOK.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        employee_id: int | None = None,
+    ) -> list[AccountBooking]:
+        """Return bookings filtered by ISO date range and/or employee."""
+        stmt = select(AccountBooking)
+        if date_from is not None:
+            stmt = stmt.where(AccountBooking.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(AccountBooking.date <= date_to)
+        if employee_id is not None:
+            stmt = stmt.where(AccountBooking.employee_id == employee_id)
+        stmt = stmt.order_by(AccountBooking.date, AccountBooking.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, booking_id: int) -> AccountBooking | None:
+        """Return a single booking by ID, or None."""
+        return self.session.get(AccountBooking, booking_id)
+
+
+class OvertimeEntryRepository:
+    """Data access for manual overtime adjustments (5OVER.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        employee_id: int | None = None,
+    ) -> list[OvertimeEntry]:
+        """Return overtime entries filtered by ISO date range and/or employee."""
+        stmt = select(OvertimeEntry)
+        if date_from is not None:
+            stmt = stmt.where(OvertimeEntry.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(OvertimeEntry.date <= date_to)
+        if employee_id is not None:
+            stmt = stmt.where(OvertimeEntry.employee_id == employee_id)
+        stmt = stmt.order_by(OvertimeEntry.date, OvertimeEntry.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, entry_id: int) -> OvertimeEntry | None:
+        """Return a single overtime entry by ID, or None."""
+        return self.session.get(OvertimeEntry, entry_id)
+
+
+class LeaveEntitlementRepository:
+    """Data access for annual leave entitlements (5LEAEN.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        year: int | None = None,
+        employee_id: int | None = None,
+    ) -> list[LeaveEntitlement]:
+        """Return leave entitlements filtered by year and/or employee."""
+        stmt = select(LeaveEntitlement)
+        if year is not None:
+            stmt = stmt.where(LeaveEntitlement.year == year)
+        if employee_id is not None:
+            stmt = stmt.where(LeaveEntitlement.employee_id == employee_id)
+        stmt = stmt.order_by(LeaveEntitlement.year, LeaveEntitlement.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, entitlement_id: int) -> LeaveEntitlement | None:
+        """Return a single entitlement by ID, or None."""
+        return self.session.get(LeaveEntitlement, entitlement_id)

--- a/sp5lib/orm/sync.py
+++ b/sp5lib/orm/sync.py
@@ -23,11 +23,14 @@ from sqlalchemy.orm import Session
 from .base import get_session
 from .models import (
     Absence,
+    AccountBooking,
     Employee,
     Group,
     GroupAssignment,
     Holiday,
+    LeaveEntitlement,
     LeaveType,
+    OvertimeEntry,
     Period,
     Shift,
     ShiftAssignment,
@@ -488,6 +491,101 @@ def sync_periods(session: Session, daten_path: str) -> int:
     return count
 
 
+def sync_book(session: Session, daten_path: str) -> int:
+    """Sync manual account/time bookings from 5BOOK.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "BOOK")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        book_id = r.get("ID")
+        if not book_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        bk = session.get(AccountBooking, book_id)
+        if bk is None:
+            bk = AccountBooking(id=book_id)
+            session.add(bk)
+
+        bk.employee_id = r.get("EMPLOYEEID", 0) or 0
+        bk.date = date
+        bk.booking_type = r.get("TYPE", 0) or 0
+        bk.value = float(r.get("VALUE", 0) or 0)
+        bk.note = str(r.get("NOTE") or "").strip()
+        count += 1
+
+    if skipped:
+        _log.warning("sync_book: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_overtime(session: Session, daten_path: str) -> int:
+    """Sync manual overtime adjustments from 5OVER.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "OVER")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        ot_id = r.get("ID")
+        if not ot_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        ot = session.get(OvertimeEntry, ot_id)
+        if ot is None:
+            ot = OvertimeEntry(id=ot_id)
+            session.add(ot)
+
+        ot.employee_id = r.get("EMPLOYEEID", 0) or 0
+        ot.date = date
+        ot.hours = float(r.get("HOURS", 0) or 0)
+        count += 1
+
+    if skipped:
+        _log.warning("sync_overtime: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_leave_entitlements(session: Session, daten_path: str) -> int:
+    """Sync annual leave entitlements from 5LEAEN.DBF.
+
+    Keyed by year (not a date); rows without an ID are skipped. DBF fields:
+    ENTITLEMNT -> entitlement, REST -> carry_forward, INDAYS -> in_days.
+    """
+    rows = _read_dbf(daten_path, "LEAEN")
+    count = 0
+
+    for r in rows:
+        le_id = r.get("ID")
+        if not le_id:
+            continue
+
+        le = session.get(LeaveEntitlement, le_id)
+        if le is None:
+            le = LeaveEntitlement(id=le_id)
+            session.add(le)
+
+        le.employee_id = r.get("EMPLOYEEID", 0) or 0
+        le.year = r.get("YEAR", 0) or 0
+        le.leave_type_id = r.get("LEAVETYPID", 0) or 0
+        le.entitlement = float(r.get("ENTITLEMNT", 0) or 0)
+        le.carry_forward = float(r.get("REST", 0) or 0)
+        le.in_days = bool(r.get("INDAYS", 1))
+        count += 1
+
+    session.flush()
+    return count
+
+
 def sync_all(engine, daten_path: str) -> dict[str, int]:
     """Sync all supported tables from DBF into the ORM database.
 
@@ -507,6 +605,9 @@ def sync_all(engine, daten_path: str) -> dict[str, int]:
         stats["absences"] = sync_absences(session, daten_path)
         stats["holidays"] = sync_holidays(session, daten_path)
         stats["periods"] = sync_periods(session, daten_path)
+        stats["bookings"] = sync_book(session, daten_path)
+        stats["overtime"] = sync_overtime(session, daten_path)
+        stats["leave_entitlements"] = sync_leave_entitlements(session, daten_path)
         session.commit()
         _log.info("ORM sync complete: %s", stats)
         return stats

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -15,13 +15,19 @@ import pytest
 from sp5lib.orm import (
     Absence,
     AbsenceRepository,
+    AccountBooking,
+    AccountBookingRepository,
     Employee,
     Group,
     GroupAssignment,
     Holiday,
     HolidayRepository,
+    LeaveEntitlement,
+    LeaveEntitlementRepository,
     LeaveType,
     LeaveTypeRepository,
+    OvertimeEntry,
+    OvertimeEntryRepository,
     Period,
     PeriodRepository,
     ScheduleEntry,
@@ -552,3 +558,138 @@ def test_sync_all_includes_phase4_tables(engine, monkeypatch):
     stats = sync.sync_all(engine, "/x")
     assert stats["holidays"] == 1
     assert stats["periods"] == 1
+
+
+# ─── Phase 5: bookings / overtime / leave entitlements ──────────────────────────
+
+
+def test_init_db_creates_phase5_tables(engine):
+    from sqlalchemy import inspect
+
+    tables = set(inspect(engine).get_table_names())
+    assert {"bookings_pg", "overtime_records", "leave_entitlements"} <= tables
+
+
+def test_phase5_legacy_aliases():
+    from sp5lib.orm import Booking, OvertimeRecord, models_pg
+
+    assert Booking is AccountBooking
+    assert OvertimeRecord is OvertimeEntry
+    assert models_pg.Booking is AccountBooking
+    assert models_pg.OvertimeRecord is OvertimeEntry
+    assert models_pg.LeaveEntitlement is LeaveEntitlement
+
+
+def test_account_booking_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                AccountBooking(id=1, employee_id=10, date="2026-01-05", value=2.5),
+                AccountBooking(id=2, employee_id=10, date="2026-02-10", value=-1.0),
+                AccountBooking(id=3, employee_id=20, date="2026-01-20", value=8.0),
+            ]
+        )
+        session.flush()
+        repo = AccountBookingRepository(session)
+        assert [b.id for b in repo.list()] == [1, 3, 2]  # by date
+        assert [b.id for b in repo.list(employee_id=10)] == [1, 2]
+        assert [b.id for b in repo.list(date_from="2026-01-01", date_to="2026-01-31")] == [1, 3]
+        assert repo.get(3).value == 8.0
+        assert repo.get(99) is None
+
+
+def test_overtime_entry_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                OvertimeEntry(id=1, employee_id=10, date="2026-01-31", hours=5.0),
+                OvertimeEntry(id=2, employee_id=11, date="2026-02-28", hours=-2.0),
+            ]
+        )
+        session.flush()
+        repo = OvertimeEntryRepository(session)
+        assert [o.id for o in repo.list(employee_id=10)] == [1]
+        assert [o.id for o in repo.list(date_from="2026-02-01")] == [2]
+        assert repo.get(1).hours == 5.0
+
+
+def test_leave_entitlement_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                LeaveEntitlement(id=1, employee_id=10, year=2025, leave_type_id=1, entitlement=30.0),
+                LeaveEntitlement(id=2, employee_id=10, year=2026, leave_type_id=1, entitlement=32.0),
+                LeaveEntitlement(id=3, employee_id=20, year=2026, leave_type_id=1, entitlement=28.0),
+            ]
+        )
+        session.flush()
+        repo = LeaveEntitlementRepository(session)
+        assert [e.id for e in repo.list(year=2026)] == [2, 3]
+        assert [e.id for e in repo.list(employee_id=10)] == [1, 2]
+        assert [e.id for e in repo.list(year=2026, employee_id=10)] == [2]
+        assert repo.get(1).entitlement == 30.0
+
+
+def test_phase5_to_dict_mirror_dbf_keys():
+    assert AccountBooking(id=1, employee_id=10, date="2026-01-05", booking_type=2,
+                          value=2.5, note="x").to_dict() == {
+        "ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-05", "TYPE": 2, "VALUE": 2.5, "NOTE": "x",
+    }
+    assert OvertimeEntry(id=1, employee_id=10, date="2026-01-31", hours=5.0).to_dict() == {
+        "ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-31", "HOURS": 5.0,
+    }
+    d = LeaveEntitlement(id=1, employee_id=10, year=2026, leave_type_id=1,
+                         entitlement=30.0, carry_forward=2.0, in_days=True).to_dict()
+    assert d == {
+        "ID": 1, "EMPLOYEEID": 10, "YEAR": 2026, "LEAVETYPID": 1,
+        "ENTITLEMNT": 30.0, "REST": 2.0, "INDAYS": True,
+    }
+
+
+def test_sync_book_overtime_entitlements(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "BOOK": [
+                {"ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-05", "TYPE": 1,
+                 "VALUE": 2.5, "NOTE": "Gutschrift"},
+                {"ID": 2, "EMPLOYEEID": 10, "DATE": "", "VALUE": 1.0},  # invalid date -> skip
+            ],
+            "OVER": [
+                {"ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-31", "HOURS": 5.0},
+            ],
+            "LEAEN": [
+                {"ID": 1, "EMPLOYEEID": 10, "YEAR": 2026, "LEAVETYPID": 1,
+                 "ENTITLEMNT": 30.0, "REST": 2.5, "INDAYS": True},
+            ],
+        },
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_book(session, "/x") == 1            # one skipped (blank date)
+        assert sync.sync_overtime(session, "/x") == 1
+        assert sync.sync_leave_entitlements(session, "/x") == 1
+        assert AccountBookingRepository(session).get(1).note == "Gutschrift"
+        assert OvertimeEntryRepository(session).get(1).hours == 5.0
+        le = LeaveEntitlementRepository(session).get(1)
+        assert le.entitlement == 30.0 and le.carry_forward == 2.5 and le.in_days is True
+
+
+def test_sync_all_includes_phase5_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "BOOK": [{"ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-05", "VALUE": 2.5}],
+            "OVER": [{"ID": 1, "EMPLOYEEID": 10, "DATE": "2026-01-31", "HOURS": 5.0}],
+            "LEAEN": [{"ID": 1, "EMPLOYEEID": 10, "YEAR": 2026, "ENTITLEMNT": 30.0}],
+        },
+    )
+    stats = sync.sync_all(engine, "/x")
+    assert stats["bookings"] == 1
+    assert stats["overtime"] == 1
+    assert stats["leave_entitlements"] == 1
+    # full table coverage: 14 logical tables in sync_all
+    assert len(stats) == 14


### PR DESCRIPTION
Implements **from-app issue #9** — ORM Phase 5: the data behind the time-account / overtime / leave-balance features.

## What

- **Models** `AccountBooking` (`5BOOK.DBF` → `bookings_pg`), `OvertimeEntry` (`5OVER.DBF` → `overtime_records`), `LeaveEntitlement` (`5LEAEN.DBF` → `leave_entitlements`) — importable from `sp5lib.orm`, `to_dict()` mirroring the real DBF keys. `init_db()` creates the tables.
- **Repositories** `AccountBookingRepository` / `OvertimeEntryRepository` with `list(date_from=None, date_to=None, employee_id=None)` + `get(id)`; `LeaveEntitlementRepository` with `list(year=None, employee_id=None)` + `get(id)`.
- **Sync** `sync_book` / `sync_overtime` / `sync_leave_entitlements`, wired into `sync_all()`. `BOOK`/`OVER` rows with blank/invalid `DATE` are skipped + logged. **`sync_all()` now covers 14 tables.**

## Decisions / notes

- The three models already existed in `models_pg.py` as `Booking` / `OvertimeRecord` / `LeaveEntitlement` (not imported by `pg_database`). As in Phases 2–4 they're now **canonical in `models.py`** and **re-exported** from `models_pg.py`; the old names **`Booking` → `AccountBooking`** and **`OvertimeRecord` → `OvertimeEntry`** stay importable as **aliases** (same tablenames `bookings_pg` / `overtime_records`, kept to avoid schema churn).
- **DBF field mapping** (verified against `database.py`): 5BOOK `TYPE`/`VALUE`/`NOTE`; 5OVER `HOURS`; 5LEAEN `ENTITLEMNT`→`entitlement`, `REST`→`carry_forward`, `INDAYS`→`in_days`. `to_dict()` mirrors the DBF spellings.
- DBF IDs for these tables are globally unique (`max+1` pattern), so ID-based upsert is used (consistent with the definition-table syncs); references stay FK-tolerant (plain indexed integers).

## Acceptance criteria

- [x] Models in `models.py`, exported via `__init__`, `to_dict()` mirrors DBF keys, FK-tolerant, robust date parsing
- [x] Repositories with the specified filters
- [x] `sync_book`/`sync_overtime`/`sync_leave_entitlements` in `sync_all`; `sync_all` completes (14 tables)
- [x] Tests (in-memory SQLite); SQLite + Postgres schema synchronous (single source)
- [x] Version → **1.5.0** for PyPI (tag after merge)

Local: `ruff` clean, **54 tests pass**, `build` + `twine check --strict` clean.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)