### PR TITLE
feat(orm): Phase 6 — demand, cycles & restrictions (read-mirror complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-05-27
+
+ORM Phase 6 — completes the read-only mirror with the demand, rotation-cycle
+and restriction tables. Additive and backward compatible. `sync_all()` now
+covers 19 tables.
+
+### Added
+
+- **`ShiftDemand`** (`staffing_requirements`, from `5SHDEM.DBF`),
+  **`SpecialDemand`** (`special_demands`, `5SPDEM.DBF`), **`Cycle`** (`cycles`,
+  `5CYCLE.DBF`), **`CycleAssignment`** (`cycle_assignments`, `5CYASS.DBF`) and
+  **`Restriction`** (`restrictions`, `5RESTR.DBF`) ORM models, importable from
+  `sp5lib.orm`, with `to_dict()` mirroring the real DBF keys. `init_db()`
+  creates the tables.
+- Repositories: **`ShiftDemandRepository`** `list(shift_id, weekday, group_id)`,
+  **`SpecialDemandRepository`** `list(date_from, date_to, shift_id)`,
+  **`CycleRepository`** `list(include_hidden=False)`,
+  **`CycleAssignmentRepository`** `list(employee_id, cycle_id)`,
+  **`RestrictionRepository`** `list(employee_id, shift_id)` — all with `get(id)`.
+- DBF → ORM upsert `sync.sync_shift_demand`, `sync.sync_special_demand`,
+  `sync.sync_cycles`, `sync.sync_cycle_assignments`, `sync.sync_restrictions`,
+  wired into `sync.sync_all()`. `5SPDEM` rows with a blank/invalid `DATE` are
+  skipped and logged. `sync_cycle_assignments` follows the 5GRASG pattern
+  (autoincrement PK, de-dup on `(employee_id, cycle_id, start)`) since the DBF
+  `ID` is not guaranteed unique.
+
+### Changed
+
+- `ShiftDemand` / `Cycle` / `CycleAssignment` / `Restriction` are defined
+  canonically in `sp5lib.orm.models` and re-exported from `sp5lib.orm.models_pg`.
+  The previous name **`StaffingRequirement`** (→ `ShiftDemand`) remains
+  importable as an alias (same table `staffing_requirements`), so existing
+  imports keep working.
+
+### Notes
+
+- DBF field mapping (verified against `database.py`): 5SHDEM/5SPDEM `MIN`/`MAX`;
+  5RESTR free-text reason is the `RESERVED` field (`to_dict()` exposes it as
+  `RESERVED`). 5CYCLE length is `SIZE`/`UNIT`.
+
 ## [1.5.0] - 2026-05-27
 
 ORM Phase 5 — account bookings, overtime and leave entitlements (the data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libopenschichtplaner5"
-version = "1.5.0"
+version = "1.6.0"
 description = "Read and write the original Schichtplaner5 FoxPro .DBF database files, plus the SQLite/PostgreSQL ORM and sync layer used by OpenSchichtplaner5."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/sp5lib/orm/README.md
+++ b/sp5lib/orm/README.md
@@ -88,8 +88,9 @@ This initial implementation covers:
 3. ✅ **Phase 3**: ORM models + repositories + DBF sync for Schedule entries (MASHI → ShiftAssignment, SPSHI → SpecialShift, ABSEN → Absence)
 4. ✅ **Phase 4**: ORM models + repositories + DBF sync for reference tables (5HOLID → Holiday, 5PERIO → Period); `sync_all()` now runs over all tables
 5. ✅ **Phase 5**: ORM models + repositories + DBF sync for account/overtime/entitlements (5BOOK → AccountBooking, 5OVER → OvertimeEntry, 5LEAEN → LeaveEntitlement); `sync_all()` covers 14 tables
-6. **Next**: Wire ORM repositories into FastAPI routers (dual-read) — app-side
-7. **Later**: Switch write path to ORM, keep DBF sync for legacy; then drop the DBF dependency and run on PostgreSQL
+6. ✅ **Phase 6**: demand, cycles & restrictions (5SHDEM → ShiftDemand, 5SPDEM → SpecialDemand, 5CYCLE → Cycle, 5CYASS → CycleAssignment, 5RESTR → Restriction). The read-only mirror is complete — `sync_all()` covers 19 tables
+7. **Next**: Wire ORM repositories into FastAPI routers (dual-read) — app-side
+8. **Later (Phase 7)**: Write-back (ORM → DBF) / repository write methods — deliberately separate
 
 ## Usage Example
 

--- a/sp5lib/orm/__init__.py
+++ b/sp5lib/orm/__init__.py
@@ -22,6 +22,8 @@ from .models import (
     Absence,
     AccountBooking,
     Company,
+    Cycle,
+    CycleAssignment,
     Employee,
     Group,
     GroupAssignment,
@@ -30,14 +32,19 @@ from .models import (
     LeaveType,
     OvertimeEntry,
     Period,
+    Restriction,
     Shift,
     ShiftAssignment,
+    ShiftDemand,
+    SpecialDemand,
     SpecialShift,
     Workplace,
 )
 from .repository import (
     AbsenceRepository,
     AccountBookingRepository,
+    CycleAssignmentRepository,
+    CycleRepository,
     EmployeeRepository,
     GroupRepository,
     HolidayRepository,
@@ -45,8 +52,11 @@ from .repository import (
     LeaveTypeRepository,
     OvertimeEntryRepository,
     PeriodRepository,
+    RestrictionRepository,
     ShiftAssignmentRepository,
+    ShiftDemandRepository,
     ShiftRepository,
+    SpecialDemandRepository,
     SpecialShiftRepository,
     WorkplaceRepository,
 )
@@ -55,6 +65,7 @@ from .repository import (
 ScheduleEntry = ShiftAssignment
 Booking = AccountBooking
 OvertimeRecord = OvertimeEntry
+StaffingRequirement = ShiftDemand
 
 __all__ = [
     # Engine / session / schema
@@ -84,6 +95,13 @@ __all__ = [
     "OvertimeEntry",
     "OvertimeRecord",
     "LeaveEntitlement",
+    # Demand / cycle / restriction (Phase 6) models
+    "ShiftDemand",
+    "StaffingRequirement",
+    "SpecialDemand",
+    "Cycle",
+    "CycleAssignment",
+    "Restriction",
     # Repositories
     "EmployeeRepository",
     "GroupRepository",
@@ -98,4 +116,9 @@ __all__ = [
     "AccountBookingRepository",
     "OvertimeEntryRepository",
     "LeaveEntitlementRepository",
+    "ShiftDemandRepository",
+    "SpecialDemandRepository",
+    "CycleRepository",
+    "CycleAssignmentRepository",
+    "RestrictionRepository",
 ]

--- a/sp5lib/orm/models.py
+++ b/sp5lib/orm/models.py
@@ -667,3 +667,160 @@ class LeaveEntitlement(Base):
             "REST": self.carry_forward,
             "INDAYS": self.in_days,
         }
+
+
+# ── Phase 6: demand, cycles, restrictions (read-mirror completion) ───────────
+# Defined canonically here and re-exported from models_pg.py. StaffingRequirement
+# remains available there as an alias of ShiftDemand. All references are plain
+# indexed integers (no DB-level FK), consistent with the other roster tables.
+
+
+class ShiftDemand(Base):
+    """Recurring shift demand per weekday (Schichtbedarf) — maps to 5SHDEM.DBF."""
+
+    __tablename__ = "staffing_requirements"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(Integer, default=0)
+    weekday: Mapped[int] = mapped_column(Integer, default=0)
+    shift_id: Mapped[int] = mapped_column(Integer, default=0)
+    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
+    min_staff: Mapped[int] = mapped_column(Integer, default=0, doc="DBF MIN")
+    max_staff: Mapped[int] = mapped_column(Integer, default=0, doc="DBF MAX")
+
+    __table_args__ = (
+        Index("idx_shdem_shift", "shift_id"),
+        Index("idx_shdem_weekday", "weekday"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ShiftDemand(id={self.id}, shift={self.shift_id}, weekday={self.weekday})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "GROUPID": self.group_id,
+            "WEEKDAY": self.weekday,
+            "SHIFTID": self.shift_id,
+            "WORKPLACID": self.workplace_id,
+            "MIN": self.min_staff,
+            "MAX": self.max_staff,
+        }
+
+
+class SpecialDemand(Base):
+    """Date-specific shift demand (Sonderbedarf) — maps to 5SPDEM.DBF."""
+
+    __tablename__ = "special_demands"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(Integer, default=0)
+    date: Mapped[str] = mapped_column(String(10), nullable=False, doc="ISO date YYYY-MM-DD")
+    shift_id: Mapped[int] = mapped_column(Integer, default=0)
+    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
+    min_staff: Mapped[int] = mapped_column(Integer, default=0, doc="DBF MIN")
+    max_staff: Mapped[int] = mapped_column(Integer, default=0, doc="DBF MAX")
+
+    __table_args__ = (
+        Index("idx_spdem_date", "date"),
+        Index("idx_spdem_shift", "shift_id"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SpecialDemand(id={self.id}, date='{self.date}', shift={self.shift_id})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "GROUPID": self.group_id,
+            "DATE": self.date,
+            "SHIFTID": self.shift_id,
+            "WORKPLACID": self.workplace_id,
+            "MIN": self.min_staff,
+            "MAX": self.max_staff,
+        }
+
+
+class Cycle(Base):
+    """Shift rotation cycle definition (Zyklus) — maps to 5CYCLE.DBF."""
+
+    __tablename__ = "cycles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, default=0)
+    size: Mapped[int] = mapped_column(Integer, default=1, doc="Cycle length")
+    unit: Mapped[int] = mapped_column(Integer, default=1)
+    hide: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    def __repr__(self) -> str:
+        return f"<Cycle(id={self.id}, name='{self.name}')>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "NAME": self.name,
+            "POSITION": self.position,
+            "SIZE": self.size,
+            "UNIT": self.unit,
+            "HIDE": self.hide,
+        }
+
+
+class CycleAssignment(Base):
+    """Employee ↔ rotation-cycle assignment — maps to 5CYASS.DBF."""
+
+    __tablename__ = "cycle_assignments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    cycle_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    start: Mapped[str | None] = mapped_column(String(10), default="")
+    end: Mapped[str | None] = mapped_column(String(10), default="")
+    entrance: Mapped[str | None] = mapped_column(String(10), default="")
+
+    __table_args__ = (Index("idx_cyass_emp", "employee_id"),)
+
+    def __repr__(self) -> str:
+        return f"<CycleAssignment(id={self.id}, emp={self.employee_id}, cycle={self.cycle_id})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "EMPLOYEEID": self.employee_id,
+            "CYCLEID": self.cycle_id,
+            "START": self.start or "",
+            "END": self.end or "",
+            "ENTRANCE": self.entrance or "",
+        }
+
+
+class Restriction(Base):
+    """Employee shift restriction / ban — maps to 5RESTR.DBF.
+
+    The free-text reason is stored in the DBF ``RESERVED`` field.
+    """
+
+    __tablename__ = "restrictions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    shift_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    weekday: Mapped[int] = mapped_column(Integer, default=0)
+    restrict: Mapped[int] = mapped_column(Integer, default=1)
+    reason: Mapped[str | None] = mapped_column(String(20), default="", doc="DBF RESERVED")
+
+    __table_args__ = (Index("idx_restr_emp", "employee_id"),)
+
+    def __repr__(self) -> str:
+        return f"<Restriction(id={self.id}, emp={self.employee_id}, shift={self.shift_id})>"
+
+    def to_dict(self) -> dict:
+        return {
+            "ID": self.id,
+            "EMPLOYEEID": self.employee_id,
+            "SHIFTID": self.shift_id,
+            "WEEKDAY": self.weekday,
+            "RESTRICT": self.restrict,
+            "RESERVED": self.reason or "",
+        }

--- a/sp5lib/orm/models_pg.py
+++ b/sp5lib/orm/models_pg.py
@@ -24,25 +24,32 @@ from .base import Base
 from .models import (  # noqa: F401,E402
     Absence,
     AccountBooking,
+    Cycle,
+    CycleAssignment,
     Holiday,
     LeaveEntitlement,
     LeaveType,
     OvertimeEntry,
     Period,
+    Restriction,
     Shift,
     ShiftAssignment,
+    ShiftDemand,
+    SpecialDemand,
     SpecialShift,
     Workplace,
 )
 
 # Backward-compatible aliases for models that were renamed when they moved to
 # models.py (same tables, same columns) — keep the old names importable:
-#   ScheduleEntry  -> ShiftAssignment (5MASHI, "schedule_entries")
-#   Booking        -> AccountBooking  (5BOOK,  "bookings_pg")
-#   OvertimeRecord -> OvertimeEntry   (5OVER,  "overtime_records")
+#   ScheduleEntry       -> ShiftAssignment (5MASHI, "schedule_entries")
+#   Booking             -> AccountBooking  (5BOOK,  "bookings_pg")
+#   OvertimeRecord      -> OvertimeEntry   (5OVER,  "overtime_records")
+#   StaffingRequirement -> ShiftDemand     (5SHDEM, "staffing_requirements")
 ScheduleEntry = ShiftAssignment
 Booking = AccountBooking
 OvertimeRecord = OvertimeEntry
+StaffingRequirement = ShiftDemand
 
 
 class User(Base):
@@ -79,16 +86,6 @@ class User(Base):
     totp_backup_codes: Mapped[str | None] = mapped_column(Text, default=None)
 
 
-class Cycle(Base):
-    __tablename__ = "cycles"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(100), nullable=False)
-    position: Mapped[int] = mapped_column(Integer, default=0)
-    size: Mapped[int] = mapped_column(Integer, default=1)
-    unit: Mapped[int] = mapped_column(Integer, default=1)
-    hide: Mapped[bool] = mapped_column(Boolean, default=False)
-
-
 class CycleEntry(Base):
     __tablename__ = "cycle_entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -96,16 +93,6 @@ class CycleEntry(Base):
     index: Mapped[int] = mapped_column(Integer, nullable=False)
     shift_id: Mapped[int] = mapped_column(Integer, default=0)
     workplace_id: Mapped[int] = mapped_column(Integer, default=0)
-
-
-class CycleAssignment(Base):
-    __tablename__ = "cycle_assignments"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    cycle_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    start: Mapped[str | None] = mapped_column(String(10), default="")
-    end: Mapped[str | None] = mapped_column(String(10), default="")
-    entrance: Mapped[str | None] = mapped_column(String(10), default="")
 
 
 class Note(Base):
@@ -116,16 +103,6 @@ class Note(Base):
     text1: Mapped[str | None] = mapped_column(Text, default="")
     text2: Mapped[str | None] = mapped_column(Text, default="")
     category: Mapped[str | None] = mapped_column(String(20), default="")
-
-
-class Restriction(Base):
-    __tablename__ = "restrictions"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    employee_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    shift_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    weekday: Mapped[int] = mapped_column(Integer, default=0)
-    restrict: Mapped[int] = mapped_column(Integer, default=1)
-    reason: Mapped[str | None] = mapped_column(String(20), default="")
 
 
 class HolidayBan(Base):
@@ -149,17 +126,6 @@ class ExtraCharge(Base):
     validdays: Mapped[str | None] = mapped_column(String(20), default="0000000")
     holrule: Mapped[int] = mapped_column(Integer, default=0)
     hide: Mapped[bool] = mapped_column(Boolean, default=False)
-
-
-class StaffingRequirement(Base):
-    __tablename__ = "staffing_requirements"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    group_id: Mapped[int] = mapped_column(Integer, default=0)
-    weekday: Mapped[int] = mapped_column(Integer, default=0)
-    shift_id: Mapped[int] = mapped_column(Integer, default=0)
-    workplace_id: Mapped[int] = mapped_column(Integer, default=0)
-    min_staff: Mapped[int] = mapped_column(Integer, default=0)
-    max_staff: Mapped[int] = mapped_column(Integer, default=0)
 
 
 class Settings(Base):

--- a/sp5lib/orm/repository.py
+++ b/sp5lib/orm/repository.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import Session
 from .models import (
     Absence,
     AccountBooking,
+    Cycle,
+    CycleAssignment,
     Employee,
     Group,
     GroupAssignment,
@@ -24,8 +26,11 @@ from .models import (
     LeaveType,
     OvertimeEntry,
     Period,
+    Restriction,
     Shift,
     ShiftAssignment,
+    ShiftDemand,
+    SpecialDemand,
     SpecialShift,
     Workplace,
 )
@@ -474,3 +479,127 @@ class LeaveEntitlementRepository:
     def get(self, entitlement_id: int) -> LeaveEntitlement | None:
         """Return a single entitlement by ID, or None."""
         return self.session.get(LeaveEntitlement, entitlement_id)
+
+
+class ShiftDemandRepository:
+    """Data access for recurring shift demand (5SHDEM.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        shift_id: int | None = None,
+        weekday: int | None = None,
+        group_id: int | None = None,
+    ) -> list[ShiftDemand]:
+        """Return shift demand rows, optionally filtered by shift/weekday/group."""
+        stmt = select(ShiftDemand)
+        if shift_id is not None:
+            stmt = stmt.where(ShiftDemand.shift_id == shift_id)
+        if weekday is not None:
+            stmt = stmt.where(ShiftDemand.weekday == weekday)
+        if group_id is not None:
+            stmt = stmt.where(ShiftDemand.group_id == group_id)
+        stmt = stmt.order_by(ShiftDemand.weekday, ShiftDemand.shift_id, ShiftDemand.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, demand_id: int) -> ShiftDemand | None:
+        """Return a single shift-demand row by ID, or None."""
+        return self.session.get(ShiftDemand, demand_id)
+
+
+class SpecialDemandRepository:
+    """Data access for date-specific shift demand (5SPDEM.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        shift_id: int | None = None,
+    ) -> list[SpecialDemand]:
+        """Return special demand rows filtered by ISO date range and/or shift."""
+        stmt = select(SpecialDemand)
+        if date_from is not None:
+            stmt = stmt.where(SpecialDemand.date >= date_from)
+        if date_to is not None:
+            stmt = stmt.where(SpecialDemand.date <= date_to)
+        if shift_id is not None:
+            stmt = stmt.where(SpecialDemand.shift_id == shift_id)
+        stmt = stmt.order_by(SpecialDemand.date, SpecialDemand.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, demand_id: int) -> SpecialDemand | None:
+        """Return a single special-demand row by ID, or None."""
+        return self.session.get(SpecialDemand, demand_id)
+
+
+class CycleRepository:
+    """Data access for rotation-cycle definitions (5CYCLE.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(self, include_hidden: bool = False) -> list[Cycle]:
+        """Return all cycles, ordered by position."""
+        stmt = select(Cycle).order_by(Cycle.position)
+        if not include_hidden:
+            stmt = stmt.where(Cycle.hide == False)  # noqa: E712
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, cycle_id: int) -> Cycle | None:
+        """Return a single cycle by ID, or None."""
+        return self.session.get(Cycle, cycle_id)
+
+
+class CycleAssignmentRepository:
+    """Data access for employee ↔ cycle assignments (5CYASS.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        employee_id: int | None = None,
+        cycle_id: int | None = None,
+    ) -> list[CycleAssignment]:
+        """Return cycle assignments, optionally filtered by employee/cycle."""
+        stmt = select(CycleAssignment)
+        if employee_id is not None:
+            stmt = stmt.where(CycleAssignment.employee_id == employee_id)
+        if cycle_id is not None:
+            stmt = stmt.where(CycleAssignment.cycle_id == cycle_id)
+        stmt = stmt.order_by(CycleAssignment.employee_id, CycleAssignment.start, CycleAssignment.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, assignment_id: int) -> CycleAssignment | None:
+        """Return a single cycle assignment by ID, or None."""
+        return self.session.get(CycleAssignment, assignment_id)
+
+
+class RestrictionRepository:
+    """Data access for employee shift restrictions (5RESTR.DBF)."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list(
+        self,
+        employee_id: int | None = None,
+        shift_id: int | None = None,
+    ) -> list[Restriction]:
+        """Return restrictions, optionally filtered by employee/shift."""
+        stmt = select(Restriction)
+        if employee_id is not None:
+            stmt = stmt.where(Restriction.employee_id == employee_id)
+        if shift_id is not None:
+            stmt = stmt.where(Restriction.shift_id == shift_id)
+        stmt = stmt.order_by(Restriction.employee_id, Restriction.id)
+        return list(self.session.scalars(stmt).all())
+
+    def get(self, restriction_id: int) -> Restriction | None:
+        """Return a single restriction by ID, or None."""
+        return self.session.get(Restriction, restriction_id)

--- a/sp5lib/orm/sync.py
+++ b/sp5lib/orm/sync.py
@@ -24,6 +24,8 @@ from .base import get_session
 from .models import (
     Absence,
     AccountBooking,
+    Cycle,
+    CycleAssignment,
     Employee,
     Group,
     GroupAssignment,
@@ -32,8 +34,11 @@ from .models import (
     LeaveType,
     OvertimeEntry,
     Period,
+    Restriction,
     Shift,
     ShiftAssignment,
+    ShiftDemand,
+    SpecialDemand,
     SpecialShift,
     Workplace,
 )
@@ -586,6 +591,159 @@ def sync_leave_entitlements(session: Session, daten_path: str) -> int:
     return count
 
 
+def sync_shift_demand(session: Session, daten_path: str) -> int:
+    """Sync recurring shift demand from 5SHDEM.DBF (keyed by weekday, no date)."""
+    rows = _read_dbf(daten_path, "SHDEM")
+    count = 0
+
+    for r in rows:
+        dem_id = r.get("ID")
+        if not dem_id:
+            continue
+
+        dem = session.get(ShiftDemand, dem_id)
+        if dem is None:
+            dem = ShiftDemand(id=dem_id)
+            session.add(dem)
+
+        dem.group_id = r.get("GROUPID", 0) or 0
+        dem.weekday = r.get("WEEKDAY", 0) or 0
+        dem.shift_id = r.get("SHIFTID", 0) or 0
+        dem.workplace_id = r.get("WORKPLACID", 0) or 0
+        dem.min_staff = r.get("MIN", 0) or 0
+        dem.max_staff = r.get("MAX", 0) or 0
+        count += 1
+
+    session.flush()
+    return count
+
+
+def sync_special_demand(session: Session, daten_path: str) -> int:
+    """Sync date-specific shift demand from 5SPDEM.DBF (invalid dates skipped)."""
+    rows = _read_dbf(daten_path, "SPDEM")
+    count = 0
+    skipped = 0
+
+    for r in rows:
+        dem_id = r.get("ID")
+        if not dem_id:
+            continue
+        date = _valid_date(r.get("DATE"))
+        if date is None:
+            skipped += 1
+            continue
+
+        dem = session.get(SpecialDemand, dem_id)
+        if dem is None:
+            dem = SpecialDemand(id=dem_id)
+            session.add(dem)
+
+        dem.group_id = r.get("GROUPID", 0) or 0
+        dem.date = date
+        dem.shift_id = r.get("SHIFTID", 0) or 0
+        dem.workplace_id = r.get("WORKPLACID", 0) or 0
+        dem.min_staff = r.get("MIN", 0) or 0
+        dem.max_staff = r.get("MAX", 0) or 0
+        count += 1
+
+    if skipped:
+        _log.warning("sync_special_demand: skipped %d row(s) with invalid date", skipped)
+    session.flush()
+    return count
+
+
+def sync_cycles(session: Session, daten_path: str) -> int:
+    """Sync rotation-cycle definitions from 5CYCLE.DBF."""
+    rows = _read_dbf(daten_path, "CYCLE")
+    count = 0
+
+    for r in rows:
+        cyc_id = r.get("ID")
+        if not cyc_id:
+            continue
+
+        cyc = session.get(Cycle, cyc_id)
+        if cyc is None:
+            cyc = Cycle(id=cyc_id)
+            session.add(cyc)
+
+        cyc.name = str(r.get("NAME") or "").strip()
+        cyc.position = r.get("POSITION", 0) or 0
+        cyc.size = r.get("SIZE", 1) or 1
+        cyc.unit = r.get("UNIT", 1) or 1
+        cyc.hide = bool(r.get("HIDE"))
+        count += 1
+
+    session.flush()
+    return count
+
+
+def sync_cycle_assignments(session: Session, daten_path: str) -> int:
+    """Sync employee↔cycle assignments from 5CYASS.DBF (full delete + re-insert).
+
+    Like 5GRASG, the DBF ``ID`` is not relied upon as a unique key: the
+    autoincrement PK is used instead and the logical identity
+    ``(employee_id, cycle_id, start)`` is de-duplicated. Rows without an
+    employee or cycle reference are skipped.
+    """
+    rows = _read_dbf(daten_path, "CYASS")
+
+    session.query(CycleAssignment).delete()
+    session.flush()
+
+    count = 0
+    seen: set[tuple[int, int, str]] = set()
+    for r in rows:
+        emp_id = r.get("EMPLOYEEID")
+        cycle_id = r.get("CYCLEID")
+        if not emp_id or not cycle_id:
+            continue
+        start = str(r.get("START") or "").strip()
+        key = (emp_id, cycle_id, start)
+        if key in seen:
+            continue
+        seen.add(key)
+        session.add(
+            CycleAssignment(
+                employee_id=emp_id,
+                cycle_id=cycle_id,
+                start=start,
+                end=str(r.get("END") or "").strip(),
+                entrance=str(r.get("ENTRANCE") or "").strip(),
+            )
+        )
+        count += 1
+
+    session.flush()
+    return count
+
+
+def sync_restrictions(session: Session, daten_path: str) -> int:
+    """Sync employee shift restrictions from 5RESTR.DBF (reason <- RESERVED)."""
+    rows = _read_dbf(daten_path, "RESTR")
+    count = 0
+
+    for r in rows:
+        res_id = r.get("ID")
+        if not res_id:
+            continue
+
+        res = session.get(Restriction, res_id)
+        if res is None:
+            res = Restriction(id=res_id)
+            session.add(res)
+
+        res.employee_id = r.get("EMPLOYEEID", 0) or 0
+        res.shift_id = r.get("SHIFTID", 0) or 0
+        res.weekday = r.get("WEEKDAY", 0) or 0
+        res.restrict = r.get("RESTRICT", 1) or 0
+        res.reason = str(r.get("RESERVED") or "").strip()
+        count += 1
+
+    session.flush()
+    return count
+
+
 def sync_all(engine, daten_path: str) -> dict[str, int]:
     """Sync all supported tables from DBF into the ORM database.
 
@@ -608,6 +766,11 @@ def sync_all(engine, daten_path: str) -> dict[str, int]:
         stats["bookings"] = sync_book(session, daten_path)
         stats["overtime"] = sync_overtime(session, daten_path)
         stats["leave_entitlements"] = sync_leave_entitlements(session, daten_path)
+        stats["shift_demand"] = sync_shift_demand(session, daten_path)
+        stats["special_demand"] = sync_special_demand(session, daten_path)
+        stats["cycles"] = sync_cycles(session, daten_path)
+        stats["cycle_assignments"] = sync_cycle_assignments(session, daten_path)
+        stats["restrictions"] = sync_restrictions(session, daten_path)
         session.commit()
         _log.info("ORM sync complete: %s", stats)
         return stats

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -17,6 +17,10 @@ from sp5lib.orm import (
     AbsenceRepository,
     AccountBooking,
     AccountBookingRepository,
+    Cycle,
+    CycleAssignment,
+    CycleAssignmentRepository,
+    CycleRepository,
     Employee,
     Group,
     GroupAssignment,
@@ -30,11 +34,17 @@ from sp5lib.orm import (
     OvertimeEntryRepository,
     Period,
     PeriodRepository,
+    Restriction,
+    RestrictionRepository,
     ScheduleEntry,
     Shift,
     ShiftAssignment,
     ShiftAssignmentRepository,
+    ShiftDemand,
+    ShiftDemandRepository,
     ShiftRepository,
+    SpecialDemand,
+    SpecialDemandRepository,
     SpecialShift,
     SpecialShiftRepository,
     Workplace,
@@ -691,5 +701,175 @@ def test_sync_all_includes_phase5_tables(engine, monkeypatch):
     assert stats["bookings"] == 1
     assert stats["overtime"] == 1
     assert stats["leave_entitlements"] == 1
-    # full table coverage: 14 logical tables in sync_all
-    assert len(stats) == 14
+
+
+# ─── Phase 6: demand / cycles / restrictions ────────────────────────────────────
+
+
+def test_init_db_creates_phase6_tables(engine):
+    from sqlalchemy import inspect
+
+    tables = set(inspect(engine).get_table_names())
+    assert {
+        "staffing_requirements", "special_demands", "cycles",
+        "cycle_assignments", "restrictions",
+    } <= tables
+
+
+def test_phase6_aliases_and_reexport():
+    from sp5lib.orm import StaffingRequirement, models, models_pg
+
+    assert StaffingRequirement is ShiftDemand
+    assert models_pg.StaffingRequirement is ShiftDemand
+    assert models_pg.Cycle is models.Cycle is Cycle
+    assert models_pg.CycleAssignment is CycleAssignment
+    assert models_pg.Restriction is Restriction
+
+
+def test_shift_demand_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                ShiftDemand(id=1, shift_id=1, weekday=1, group_id=5, min_staff=2, max_staff=4),
+                ShiftDemand(id=2, shift_id=2, weekday=1, group_id=5, min_staff=1, max_staff=2),
+                ShiftDemand(id=3, shift_id=1, weekday=2, group_id=5, min_staff=3, max_staff=3),
+            ]
+        )
+        session.flush()
+        repo = ShiftDemandRepository(session)
+        assert [d.id for d in repo.list(shift_id=1)] == [1, 3]
+        assert [d.id for d in repo.list(weekday=1)] == [1, 2]
+        assert [d.id for d in repo.list(shift_id=1, weekday=2)] == [3]
+        assert repo.get(2).max_staff == 2
+
+
+def test_special_demand_repository(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                SpecialDemand(id=1, date="2026-01-05", shift_id=1, min_staff=2, max_staff=3),
+                SpecialDemand(id=2, date="2026-02-10", shift_id=2, min_staff=1, max_staff=1),
+            ]
+        )
+        session.flush()
+        repo = SpecialDemandRepository(session)
+        assert [d.id for d in repo.list(date_from="2026-02-01")] == [2]
+        assert [d.id for d in repo.list(shift_id=1)] == [1]
+        assert repo.get(1).max_staff == 3
+
+
+def test_cycle_repository_hide_filter(engine):
+    with session_scope(engine) as session:
+        session.add_all(
+            [
+                Cycle(id=1, name="Rotation A", position=1),
+                Cycle(id=2, name="Alt", position=2, hide=True),
+            ]
+        )
+        session.flush()
+        repo = CycleRepository(session)
+        assert [c.id for c in repo.list()] == [1]
+        assert [c.id for c in repo.list(include_hidden=True)] == [1, 2]
+        assert repo.get(1).name == "Rotation A"
+
+
+def test_cycle_assignment_and_restriction_repositories(engine):
+    with session_scope(engine) as session:
+        session.add(CycleAssignment(id=1, employee_id=10, cycle_id=1, start="2026-01-01"))
+        session.add(CycleAssignment(id=2, employee_id=11, cycle_id=1, start="2026-01-01"))
+        session.add(Restriction(id=1, employee_id=10, shift_id=3, weekday=1, reason="kein Nachtdienst"))
+        session.flush()
+        ca_repo = CycleAssignmentRepository(session)
+        assert [a.id for a in ca_repo.list(cycle_id=1)] == [1, 2]
+        assert [a.id for a in ca_repo.list(employee_id=11)] == [2]
+        r_repo = RestrictionRepository(session)
+        assert r_repo.list(employee_id=10)[0].reason == "kein Nachtdienst"
+        assert r_repo.list(shift_id=3)[0].id == 1
+
+
+def test_phase6_to_dict_mirror_dbf_keys():
+    assert ShiftDemand(id=1, group_id=5, weekday=1, shift_id=2, workplace_id=0,
+                       min_staff=2, max_staff=4).to_dict() == {
+        "ID": 1, "GROUPID": 5, "WEEKDAY": 1, "SHIFTID": 2, "WORKPLACID": 0, "MIN": 2, "MAX": 4,
+    }
+    assert SpecialDemand(id=1, group_id=0, date="2026-01-05", shift_id=2, workplace_id=0,
+                         min_staff=1, max_staff=3).to_dict() == {
+        "ID": 1, "GROUPID": 0, "DATE": "2026-01-05", "SHIFTID": 2, "WORKPLACID": 0,
+        "MIN": 1, "MAX": 3,
+    }
+    assert Restriction(id=1, employee_id=10, shift_id=3, weekday=1, restrict=1,
+                       reason="x").to_dict() == {
+        "ID": 1, "EMPLOYEEID": 10, "SHIFTID": 3, "WEEKDAY": 1, "RESTRICT": 1, "RESERVED": "x",
+    }
+
+
+def test_sync_phase6_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "SHDEM": [{"ID": 1, "GROUPID": 5, "WEEKDAY": 1, "SHIFTID": 2, "MIN": 2, "MAX": 4}],
+            "SPDEM": [
+                {"ID": 1, "GROUPID": 0, "DATE": "2026-01-05", "SHIFTID": 2, "MIN": 1, "MAX": 3},
+                {"ID": 2, "DATE": "", "SHIFTID": 2},  # invalid date -> skip
+            ],
+            "CYCLE": [{"ID": 1, "NAME": "Rotation A", "SIZE": 14, "UNIT": 1}],
+            "RESTR": [{"ID": 1, "EMPLOYEEID": 10, "SHIFTID": 3, "WEEKDAY": 1,
+                       "RESTRICT": 1, "RESERVED": "kein Nachtdienst"}],
+        },
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_shift_demand(session, "/x") == 1
+        assert sync.sync_special_demand(session, "/x") == 1   # one skipped
+        assert sync.sync_cycles(session, "/x") == 1
+        assert sync.sync_restrictions(session, "/x") == 1
+        assert ShiftDemandRepository(session).get(1).min_staff == 2
+        assert CycleRepository(session).get(1).size == 14
+        assert RestrictionRepository(session).get(1).reason == "kein Nachtdienst"
+
+
+def test_sync_cycle_assignments_non_unique_ids_and_dedup(engine, monkeypatch):
+    # Like 5GRASG: the DBF ID may repeat. Use autoincrement PK (no IntegrityError)
+    # and de-duplicate (employee_id, cycle_id, start).
+    from sqlalchemy import select
+
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {"CYASS": [
+            {"ID": 1, "EMPLOYEEID": 10, "CYCLEID": 1, "START": "2026-01-01"},
+            {"ID": 1, "EMPLOYEEID": 11, "CYCLEID": 1, "START": "2026-01-01"},  # repeated ID
+            {"ID": 2, "EMPLOYEEID": 10, "CYCLEID": 1, "START": "2026-01-01"},  # duplicate pair
+            {"ID": 3, "EMPLOYEEID": 0, "CYCLEID": 1, "START": "2026-01-01"},   # no employee -> skip
+        ]},
+    )
+    with session_scope(engine) as session:
+        assert sync.sync_cycle_assignments(session, "/x") == 2  # (10,1,..) and (11,1,..)
+        rows = list(session.scalars(select(CycleAssignment)).all())
+        assert {(r.employee_id, r.cycle_id) for r in rows} == {(10, 1), (11, 1)}
+        assert len({r.id for r in rows}) == 2  # autoincrement PKs
+
+
+def test_sync_all_includes_phase6_and_covers_19_tables(engine, monkeypatch):
+    from sp5lib.orm import sync
+
+    _patch_dbf(
+        monkeypatch,
+        {
+            "SHDEM": [{"ID": 1, "SHIFTID": 1, "WEEKDAY": 1, "MIN": 1, "MAX": 2}],
+            "SPDEM": [{"ID": 1, "DATE": "2026-01-05", "SHIFTID": 1, "MIN": 1, "MAX": 2}],
+            "CYCLE": [{"ID": 1, "NAME": "A"}],
+            "CYASS": [{"ID": 1, "EMPLOYEEID": 10, "CYCLEID": 1, "START": "2026-01-01"}],
+            "RESTR": [{"ID": 1, "EMPLOYEEID": 10, "SHIFTID": 1}],
+        },
+    )
+    stats = sync.sync_all(engine, "/x")
+    assert stats["shift_demand"] == 1
+    assert stats["special_demand"] == 1
+    assert stats["cycles"] == 1
+    assert stats["cycle_assignments"] == 1
+    assert stats["restrictions"] == 1
+    # full read-mirror coverage: 19 logical tables
+    assert len(stats) == 19


### PR DESCRIPTION
Implements **from-app issue #11** — ORM Phase 6: the remaining planning tables. Completes the **read-only ORM mirror**. `sync_all()` now covers **19 tables**.

## What

- **Models** `ShiftDemand` (`5SHDEM` → `staffing_requirements`), `SpecialDemand` (`5SPDEM` → `special_demands`), `Cycle` (`5CYCLE`), `CycleAssignment` (`5CYASS`), `Restriction` (`5RESTR`) — importable from `sp5lib.orm`, `to_dict()` mirroring the real DBF keys. `init_db()` creates the tables.
- **Repositories**: `ShiftDemandRepository.list(shift_id, weekday, group_id)`, `SpecialDemandRepository.list(date_from, date_to, shift_id)`, `CycleRepository.list(include_hidden)`, `CycleAssignmentRepository.list(employee_id, cycle_id)`, `RestrictionRepository.list(employee_id, shift_id)` — all with `get(id)`.
- **Sync** `sync_shift_demand` / `sync_special_demand` / `sync_cycles` / `sync_cycle_assignments` / `sync_restrictions`, wired into `sync_all()`. `5SPDEM` rows with blank/invalid `DATE` are skipped + logged.

## Decisions / notes

- **`sync_cycle_assignments`** follows the **5GRASG pattern**: the DBF `ID` is not relied on as a key (autoincrement PK), full delete + re-insert, de-dup on `(employee_id, cycle_id, start)`, rows without employee/cycle skipped — per the issue's explicit caution.
- The existing `models_pg` classes (`StaffingRequirement`, `Cycle`, `CycleAssignment`, `Restriction`; none imported by `pg_database`) are consolidated **canonically into `models.py`** and re-exported. **`StaffingRequirement` → `ShiftDemand`** stays importable as an alias (same table `staffing_requirements`).
- **DBF field mapping** verified against `database.py`: 5SHDEM/5SPDEM `MIN`/`MAX` (+ `GROUPID`/`WEEKDAY`/`SHIFTID`/`WORKPLACID`/`DATE`); 5RESTR reason = `RESERVED`; 5CYCLE length = `SIZE`/`UNIT`. `SpecialDemand` is a new table; the others reuse existing tablenames.
- All references stay FK-tolerant (plain indexed integers).

## Acceptance criteria

- [x] Models in `models.py`, exported via `__init__`, `to_dict()` mirrors DBF keys, FK-tolerant, robust date parsing
- [x] Repos with the specified filters; non-unique-ID strategy for cycle assignments
- [x] `sync_*` in `sync_all`; `sync_all` completes — **19 tables**
- [x] Tests (in-memory SQLite); SQLite + Postgres schema synchronous (single source)
- [x] Version → **1.6.0** for PyPI (tag after merge)

Local: `ruff` clean, **64 tests pass**, `build` + `twine check --strict` clean.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)